### PR TITLE
Non model entity creation behavior

### DIFF
--- a/Source/Samples/Yamo.Playground.CS/Program.cs
+++ b/Source/Samples/Yamo.Playground.CS/Program.cs
@@ -84,8 +84,9 @@ namespace Yamo.Playground.CS
             //Test59();
             //Test60();
             //Test61();
-            Test62();
-            Test63();
+            //Test62();
+            //Test63();
+            Test64();
         }
 
         public static MyContext CreateContext()
@@ -1216,8 +1217,8 @@ namespace Yamo.Playground.CS
                               {
                                   return c.From<ArticleCategory>()
                                           .GroupBy(x => x.ArticleId)
-                                          .Select(x => new Stats { ArticleId = x.ArticleId, CategoriesCount = Yamo.Sql.Aggregate.Count() });
-                              }, NonModelEntityCreationBehavior.AlwaysCreateInstance)
+                                          .Select(x => new Stats { ArticleId = x.ArticleId, CategoriesCount = Yamo.Sql.Aggregate.Count() }, NonModelEntityCreationBehavior.AlwaysCreateInstance);
+                              })
                               .On(j => j.T1.Id == j.T2.ArticleId)
                               .As(x => x.Stats)
                               .SelectAll()
@@ -1273,6 +1274,41 @@ namespace Yamo.Playground.CS
                                          });
                              })
                              .SelectAll()
+                             .ToList();
+            }
+        }
+
+        public static void Test64()
+        {
+            using (var db = CreateContext())
+            {
+                var list = db.From<Article>()
+                             .LeftJoin<Label>(j => j.T1.Id == j.T2.Id && j.T2.Id < 2)
+                             .Select(j => new { j.T2.Id, j.T2.Description }, NonModelEntityCreationBehavior.AlwaysCreateInstance)
+                             .ToList();
+            }
+
+            using (var db = CreateContext())
+            {
+                var list = db.From<Article>()
+                             .LeftJoin<Label>(j => j.T1.Id == j.T2.Id && j.T2.Id < 2)
+                             .SelectAll()
+                             .Include(j => j.T1.Tag, j => new { j.T2.Id, j.T2.Description }, NonModelEntityCreationBehavior.AlwaysCreateInstance)
+                             .ToList();
+            }
+            
+            using (var db = CreateContext())
+            {
+                // NullIfAllColumnsAreNull overrides AlwaysCreateInstance behavior
+                var list = db.From<Article>()
+                             .LeftJoin(c =>
+                             {
+                                 return c.From<ArticleCategory>()
+                                         .GroupBy(x => x.ArticleId)
+                                         .Select(x => new Stats { ArticleId = x.ArticleId, CategoriesCount = Yamo.Sql.Aggregate.Count() }, NonModelEntityCreationBehavior.AlwaysCreateInstance);
+                             })
+                             .On(j => j.T1.Id == j.T2.ArticleId)
+                             .Select(j => j.T2, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull)
                              .ToList();
             }
         }

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Include.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Include.vb
@@ -31,79 +31,79 @@
 
     Protected Sub GenerateIncludeWithActionWithOneEntity(builder As CodeBuilder, index As Int32, entityCount As Int32)
       Dim comment = "Includes &lt;column(s)&gt; to SELECT clause."
-      Dim params = {"action"}
+      Dim params = {"action", "behavior"}
       AddComment(builder, comment, params:=params, returns:="")
 
       Dim generic = GetGenericName(index, index = entityCount)
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function Include(<DisallowNull> action As Expression(Of Action(Of {generic}))) As SelectedSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine($"Return InternalInclude(action, {GetEntityIndexHintsForEntity(index - 1)})").PopIndent()
+      builder.Indent().AppendLine($"Public Function Include(<DisallowNull> action As Expression(Of Action(Of {generic})), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"Return InternalInclude(action, {GetEntityIndexHintsForEntity(index - 1)}, behavior)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
     Protected Sub GenerateIncludeWithKeyValueSelectorsWithOneEntity(builder As CodeBuilder, index1 As Int32, index2 As Int32, entityCount As Int32)
       Dim comment = "Includes &lt;column(s)&gt; to SELECT clause."
       Dim typeParams = {"TProperty"}
-      Dim params = {"keySelector", "valueSelector"}
+      Dim params = {"keySelector", "valueSelector", "behavior"}
       AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
 
       Dim generic1 = GetGenericName(index1, index1 = entityCount)
       Dim generic2 = GetGenericName(index2, index2 = entityCount)
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of {generic1}, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of {generic2}, TProperty))) As SelectedSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine($"Return InternalInclude(keySelector, valueSelector, {GetEntityIndexHintsForEntity(index1 - 1)}, {GetEntityIndexHintsForEntity(index2 - 1)})").PopIndent()
+      builder.Indent().AppendLine($"Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of {generic1}, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of {generic2}, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"Return InternalInclude(keySelector, valueSelector, {GetEntityIndexHintsForEntity(index1 - 1)}, {GetEntityIndexHintsForEntity(index2 - 1)}, behavior)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
     Protected Sub GenerateIncludeWithActionWithIJoin(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Includes &lt;column(s)&gt; to SELECT clause."
-      Dim params = {"action"}
+      Dim params = {"action", "behavior"}
       AddComment(builder, comment, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of {generics})))) As SelectedSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine("Return InternalInclude(action, Nothing)").PopIndent()
+      builder.Indent().AppendLine($"Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of {generics}))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Return InternalInclude(action, Nothing, behavior)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
     Protected Sub GenerateIncludeWithKeyValueSelectorsWithIJoin(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Includes &lt;column(s)&gt; to SELECT clause."
       Dim typeParams = {"TProperty"}
-      Dim params = {"keySelector", "valueSelector"}
+      Dim params = {"keySelector", "valueSelector", "behavior"}
       AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of {generics}), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of {generics}), TProperty))) As SelectedSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine("Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)").PopIndent()
+      builder.Indent().AppendLine($"Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of {generics}), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of {generics}), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
     Protected Sub GenerateInternalIncludeWithAction(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Includes &lt;column(s)&gt; to SELECT clause."
-      Dim params = {"action", "entityIndexHints"}
+      Dim params = {"action", "entityIndexHints", "behavior"}
       AddComment(builder, comment, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine("Me.Builder.IncludeToSelected(action, entityIndexHints)")
+      builder.Indent().AppendLine($"Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)")
       builder.Indent().AppendLine("Return Me").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
     Protected Sub GenerateInternalIncludeWithKeyValueSelectors(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Includes &lt;column(s)&gt; to SELECT clause."
-      Dim params = {"keySelector", "valueSelector", "keySelectorEntityIndexHints", "valueSelectorEntityIndexHints"}
+      Dim params = {"keySelector", "valueSelector", "keySelectorEntityIndexHints", "valueSelectorEntityIndexHints", "behavior"}
       AddComment(builder, comment, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine("Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)")
+      builder.Indent().AppendLine($"Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)")
       builder.Indent().AppendLine("Return Me").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Join.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Join.vb
@@ -195,13 +195,13 @@
     Protected Sub GenerateJoinWithSubquery(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds INNER JOIN clause."
       Dim typeParams = {"TJoined"}
-      Dim params = {"tableSourceFactory", "behavior"}
+      Dim params = {"tableSourceFactory"}
       AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
-      builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)").PopIndent()
+      builder.Indent().AppendLine($"Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
+      builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
@@ -286,13 +286,13 @@
     Protected Sub GenerateLeftJoinWithSubquery(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds LEFT OUTER JOIN clause."
       Dim typeParams = {"TJoined"}
-      Dim params = {"tableSourceFactory", "behavior"}
+      Dim params = {"tableSourceFactory"}
       AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
-      builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)").PopIndent()
+      builder.Indent().AppendLine($"Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
+      builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
@@ -377,13 +377,13 @@
     Protected Sub GenerateRightJoinWithSubquery(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds RIGHT OUTER JOIN clause."
       Dim typeParams = {"TJoined"}
-      Dim params = {"tableSourceFactory", "behavior"}
+      Dim params = {"tableSourceFactory"}
       AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
-      builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)").PopIndent()
+      builder.Indent().AppendLine($"Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
+      builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
@@ -468,13 +468,13 @@
     Protected Sub GenerateFullJoinWithSubquery(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds FULL OUTER JOIN clause."
       Dim typeParams = {"TJoined"}
-      Dim params = {"tableSourceFactory", "behavior"}
+      Dim params = {"tableSourceFactory"}
       AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
-      builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)").PopIndent()
+      builder.Indent().AppendLine($"Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
+      builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
@@ -519,13 +519,13 @@
     Protected Sub GenerateCrossJoinWithSubquery(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds CROSS JOIN clause."
       Dim typeParams = {"TJoined"}
-      Dim params = {"tableSourceFactory", "behavior"}
+      Dim params = {"tableSourceFactory"}
       AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
-      builder.Indent().AppendLine("Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)")
+      builder.Indent().AppendLine($"Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)")
       builder.Indent().AppendLine("Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})")
       builder.Indent().AppendLine($"Return New JoinedSelectSqlExpression(Of {generics}, TJoined)(Me.Builder, Me.Executor)").PopIndent()
       builder.Indent().AppendLine("End Function")
@@ -592,13 +592,13 @@
     Protected Sub GenerateInternalJoinWithSubquery(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds JOIN clause."
       Dim typeParams = {"TJoined"}
-      Dim params = {"joinType", "tableSourceFactory", "behavior"}
+      Dim params = {"joinType", "tableSourceFactory"}
       AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
-      builder.Indent().AppendLine("Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)")
+      builder.Indent().AppendLine($"Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)")
       builder.Indent().AppendLine($"Return New JoinSelectSqlExpression(Of {generics}, TJoined)(Me.Builder, Me.Executor)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Select.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Select.vb
@@ -66,50 +66,50 @@
     Protected Sub GenerateSelectWithPredicateWithOneEntity(builder As CodeBuilder, index As Int32, entityCount As Int32)
       Dim comment = "Adds SELECT clause with custom columns selection."
       Dim typeParams = {"TResult"}
-      Dim params = {"selector"}
+      Dim params = {"selector", "behavior"}
       AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
 
       Dim generic = GetGenericName(index, index = entityCount)
 
-      builder.Indent().AppendLine($"Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of {generic}, TResult))) As CustomSelectSqlExpression(Of TResult)").PushIndent()
-      builder.Indent().AppendLine($"Return InternalSelect(Of TResult)(selector, {GetEntityIndexHintsForEntity(index - 1)})").PopIndent()
+      builder.Indent().AppendLine($"Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of {generic}, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)").PushIndent()
+      builder.Indent().AppendLine($"Return InternalSelect(Of TResult)(selector, {GetEntityIndexHintsForEntity(index - 1)}, behavior)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
     Protected Sub GenerateSelectWithPredicateWithAllEntities(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds SELECT clause with custom columns selection."
       Dim typeParams = {"TResult"}
-      Dim params = {"selector"}
+      Dim params = {"selector", "behavior"}
       AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of {generics}, TResult))) As CustomSelectSqlExpression(Of TResult)").PushIndent()
-      builder.Indent().AppendLine($"Return InternalSelect(Of TResult)(selector, {GetEntityIndexHintsForAllEntities(entityCount)})").PopIndent()
+      builder.Indent().AppendLine($"Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of {generics}, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)").PushIndent()
+      builder.Indent().AppendLine($"Return InternalSelect(Of TResult)(selector, {GetEntityIndexHintsForAllEntities(entityCount)}, behavior)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
     Protected Sub GenerateSelectWithPredicateWithIJoin(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds SELECT clause with custom columns selection."
       Dim typeParams = {"TResult"}
-      Dim params = {"selector"}
+      Dim params = {"selector", "behavior"}
       AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of {generics}), TResult))) As CustomSelectSqlExpression(Of TResult)").PushIndent()
-      builder.Indent().AppendLine("Return InternalSelect(Of TResult)(selector, Nothing)").PopIndent()
+      builder.Indent().AppendLine($"Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of {generics}), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)").PushIndent()
+      builder.Indent().AppendLine("Return InternalSelect(Of TResult)(selector, Nothing, behavior)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
     Protected Sub GenerateInternalSelect(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds SELECT clause with custom columns selection."
       Dim typeParams = {"TResult"}
-      Dim params = {"selector", "entityIndexHints"}
+      Dim params = {"selector", "entityIndexHints", "behavior"}
       AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
 
-      builder.Indent().AppendLine("Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)").PushIndent()
-      builder.Indent().AppendLine("Me.Builder.AddSelect(selector, entityIndexHints)")
+      builder.Indent().AppendLine("Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddSelect(selector, entityIndexHints, behavior)")
       builder.Indent().AppendLine("Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub

--- a/Source/Source/Yamo.CodeGenerator/Generator/SelectSqlExpressionCodeGenerator.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/SelectSqlExpressionCodeGenerator.vb
@@ -106,12 +106,12 @@
         builder.AppendLine()
 
         comment = $"Creates new instance of <see cref=""{GetFullClassName(entityCount)}""/>."
-        params = {"context", "tableSourceFactory", "behavior"}
+        params = {"context", "tableSourceFactory"}
         AddComment(builder, comment, params:=params)
 
-        builder.Indent().AppendLine("Friend Sub New(context As DbContext, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)), behavior As NonModelEntityCreationBehavior)").PushIndent()
+        builder.Indent().AppendLine("Friend Sub New(context As DbContext, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)))").PushIndent()
         builder.Indent().AppendLine("MyBase.New(New SelectSqlExpressionBuilder(context), New QueryExecutor(context))")
-        builder.Indent().AppendLine("Me.Builder.SetMainTableSource(Me.Executor, tableSourceFactory, behavior)").PopIndent()
+        builder.Indent().AppendLine("Me.Builder.SetMainTableSource(Me.Executor, tableSourceFactory)").PopIndent()
         builder.Indent().AppendLine("End Sub")
 
         builder.AppendLine()
@@ -128,12 +128,12 @@
         builder.AppendLine()
 
         comment = $"Creates new instance of <see cref=""{GetFullClassName(entityCount)}""/>."
-        params = {"context", "tableSourceFactory", "behavior"}
+        params = {"context", "tableSourceFactory"}
         AddComment(builder, comment, params:=params)
 
-        builder.Indent().AppendLine("Friend Sub New(context As SubqueryContext, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)), behavior As NonModelEntityCreationBehavior)").PushIndent()
+        builder.Indent().AppendLine("Friend Sub New(context As SubqueryContext, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)))").PushIndent()
         builder.Indent().AppendLine("MyBase.New(New SelectSqlExpressionBuilder(context), context.Executor)")
-        builder.Indent().AppendLine("Me.Builder.SetMainTableSource(Me.Executor, tableSourceFactory, behavior)").PopIndent()
+        builder.Indent().AppendLine("Me.Builder.SetMainTableSource(Me.Executor, tableSourceFactory)").PopIndent()
         builder.Indent().AppendLine("End Sub")
 
         builder.AppendLine()

--- a/Source/Source/Yamo/DbContext.vb
+++ b/Source/Source/Yamo/DbContext.vb
@@ -198,10 +198,9 @@ Public Class DbContext
   ''' </summary>
   ''' <typeparam name="T"></typeparam>
   ''' <param name="tableSourceFactory"></param>
-  ''' <param name="behavior"></param>
   ''' <returns></returns>
-  Public Function From(Of T)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As SelectSqlExpression(Of T)
-    Return New SelectSqlExpression(Of T)(Me, tableSourceFactory, behavior)
+  Public Function From(Of T)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SelectSqlExpression(Of T)
+    Return New SelectSqlExpression(Of T)(Me, tableSourceFactory)
   End Function
 
   ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
@@ -209,9 +209,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -220,9 +221,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
@@ -371,9 +371,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -381,9 +382,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -391,9 +393,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1}, behavior)
     End Function
 
     ''' <summary>
@@ -401,9 +404,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -412,9 +416,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
@@ -438,9 +438,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -448,9 +449,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -458,9 +460,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -468,9 +471,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2}, behavior)
     End Function
 
     ''' <summary>
@@ -478,9 +482,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -489,9 +494,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
@@ -487,9 +487,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -497,9 +498,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -507,9 +509,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -517,9 +520,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -527,9 +531,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3}, behavior)
     End Function
 
     ''' <summary>
@@ -537,9 +542,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -548,9 +554,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -554,9 +554,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -564,9 +565,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -574,9 +576,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -584,9 +587,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -594,9 +598,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -604,9 +609,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4}, behavior)
     End Function
 
     ''' <summary>
@@ -614,9 +620,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -625,9 +632,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -621,9 +621,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -631,9 +632,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -641,9 +643,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -651,9 +654,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -661,9 +665,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -671,9 +676,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -681,9 +687,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5}, behavior)
     End Function
 
     ''' <summary>
@@ -691,9 +698,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -702,9 +710,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -688,9 +688,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -698,9 +699,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -708,9 +710,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -718,9 +721,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -728,9 +732,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -738,9 +743,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -748,9 +754,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -758,9 +765,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5, 6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5, 6}, behavior)
     End Function
 
     ''' <summary>
@@ -768,9 +776,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -779,9 +788,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -745,9 +745,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -755,9 +756,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -765,9 +767,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -775,9 +778,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -785,9 +789,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -795,9 +800,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -805,9 +811,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -815,9 +822,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -825,9 +833,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -836,9 +845,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -812,9 +812,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -822,9 +823,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -832,9 +834,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -842,9 +845,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -852,9 +856,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -862,9 +867,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -872,9 +878,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -882,9 +889,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -892,9 +900,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -902,9 +911,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -913,9 +923,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -879,9 +879,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -889,9 +890,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -899,9 +901,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -909,9 +912,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -919,9 +923,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -929,9 +934,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -939,9 +945,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -949,9 +956,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -959,9 +967,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -969,9 +978,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -979,9 +989,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -990,9 +1001,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -946,9 +946,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -956,9 +957,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -966,9 +968,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -976,9 +979,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -986,9 +990,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -996,9 +1001,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1006,9 +1012,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1016,9 +1023,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1026,9 +1034,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1036,9 +1045,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1046,9 +1056,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1056,9 +1067,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1067,9 +1079,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -1013,9 +1013,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1023,9 +1024,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1033,9 +1035,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1043,9 +1046,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1053,9 +1057,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1063,9 +1068,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1073,9 +1079,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1083,9 +1090,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1093,9 +1101,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1103,9 +1112,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1113,9 +1123,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1123,9 +1134,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1133,9 +1145,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1144,9 +1157,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -1080,9 +1080,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1090,9 +1091,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1100,9 +1102,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1110,9 +1113,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1120,9 +1124,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1130,9 +1135,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1140,9 +1146,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1150,9 +1157,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1160,9 +1168,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1170,9 +1179,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1180,9 +1190,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1190,9 +1201,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1200,9 +1212,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1210,9 +1223,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1221,9 +1235,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -1147,9 +1147,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1157,9 +1158,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1167,9 +1169,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1177,9 +1180,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1187,9 +1191,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1197,9 +1202,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1207,9 +1213,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1217,9 +1224,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1227,9 +1235,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1237,9 +1246,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1247,9 +1257,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1257,9 +1268,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1267,9 +1279,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1277,9 +1290,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1287,9 +1301,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1298,9 +1313,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -1214,9 +1214,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1224,9 +1225,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1234,9 +1236,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1244,9 +1247,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1254,9 +1258,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1264,9 +1269,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1274,9 +1280,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1284,9 +1291,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1294,9 +1302,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1304,9 +1313,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1314,9 +1324,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1324,9 +1335,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1334,9 +1346,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1344,9 +1357,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1354,9 +1368,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1364,9 +1379,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1375,9 +1391,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -1281,9 +1281,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1291,9 +1292,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1301,9 +1303,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1311,9 +1314,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1321,9 +1325,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1331,9 +1336,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1341,9 +1347,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1351,9 +1358,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1361,9 +1369,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1371,9 +1380,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1381,9 +1391,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1391,9 +1402,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1401,9 +1413,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1411,9 +1424,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1421,9 +1435,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1431,9 +1446,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1441,9 +1457,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1452,9 +1469,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -1348,9 +1348,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1358,9 +1359,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1368,9 +1370,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1378,9 +1381,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1388,9 +1392,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1398,9 +1403,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1408,9 +1414,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1418,9 +1425,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1428,9 +1436,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1438,9 +1447,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1448,9 +1458,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1458,9 +1469,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1468,9 +1480,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1478,9 +1491,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1488,9 +1502,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1498,9 +1513,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1508,9 +1524,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1518,9 +1535,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1529,9 +1547,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -1415,9 +1415,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1425,9 +1426,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1435,9 +1437,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1445,9 +1448,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1455,9 +1459,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1465,9 +1470,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1475,9 +1481,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1485,9 +1492,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1495,9 +1503,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1505,9 +1514,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1515,9 +1525,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1525,9 +1536,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1535,9 +1547,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1545,9 +1558,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1555,9 +1569,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1565,9 +1580,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1575,9 +1591,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1585,9 +1602,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1595,9 +1613,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1606,9 +1625,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -1482,9 +1482,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1492,9 +1493,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1502,9 +1504,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1512,9 +1515,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1522,9 +1526,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1532,9 +1537,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1542,9 +1548,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1552,9 +1559,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1562,9 +1570,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1572,9 +1581,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1582,9 +1592,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1592,9 +1603,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1602,9 +1614,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1612,9 +1625,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1622,9 +1636,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1632,9 +1647,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1642,9 +1658,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1652,9 +1669,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1662,9 +1680,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1672,9 +1691,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1683,9 +1703,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -1549,9 +1549,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1559,9 +1560,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1569,9 +1571,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1579,9 +1582,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1589,9 +1593,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1599,9 +1604,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1609,9 +1615,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1619,9 +1626,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1629,9 +1637,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1639,9 +1648,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1649,9 +1659,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1659,9 +1670,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1669,9 +1681,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1679,9 +1692,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1689,9 +1703,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1699,9 +1714,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1709,9 +1725,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1719,9 +1736,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1729,9 +1747,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1739,9 +1758,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1749,9 +1769,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1760,9 +1781,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -1616,9 +1616,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1626,9 +1627,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1636,9 +1638,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1646,9 +1649,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1656,9 +1660,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1666,9 +1671,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1676,9 +1682,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1686,9 +1693,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1696,9 +1704,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1706,9 +1715,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1716,9 +1726,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1726,9 +1737,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1736,9 +1748,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1746,9 +1759,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1756,9 +1770,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1766,9 +1781,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1776,9 +1792,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1786,9 +1803,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1796,9 +1814,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1806,9 +1825,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1816,9 +1836,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1826,9 +1847,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1837,9 +1859,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -1683,9 +1683,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1693,9 +1694,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1703,9 +1705,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1713,9 +1716,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1723,9 +1727,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1733,9 +1738,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1743,9 +1749,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1753,9 +1760,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1763,9 +1771,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1773,9 +1782,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1783,9 +1793,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1793,9 +1804,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1803,9 +1815,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1813,9 +1826,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1823,9 +1837,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1833,9 +1848,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1843,9 +1859,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1853,9 +1870,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1863,9 +1881,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1873,9 +1892,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1883,9 +1903,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1893,9 +1914,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1903,9 +1925,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1914,9 +1937,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -1750,9 +1750,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1760,9 +1761,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1770,9 +1772,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1780,9 +1783,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1790,9 +1794,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1800,9 +1805,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1810,9 +1816,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1820,9 +1827,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1830,9 +1838,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1840,9 +1849,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1850,9 +1860,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1860,9 +1871,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1870,9 +1882,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1880,9 +1893,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1890,9 +1904,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1900,9 +1915,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1910,9 +1926,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1920,9 +1937,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1930,9 +1948,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1940,9 +1959,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1950,9 +1970,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1960,9 +1981,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1970,9 +1992,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1980,9 +2003,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1991,9 +2015,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -1817,9 +1817,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1827,9 +1828,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1837,9 +1839,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1847,9 +1850,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1857,9 +1861,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1867,9 +1872,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1877,9 +1883,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1887,9 +1894,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1897,9 +1905,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1907,9 +1916,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1917,9 +1927,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1927,9 +1938,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1937,9 +1949,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1947,9 +1960,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1957,9 +1971,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1967,9 +1982,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1977,9 +1993,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1987,9 +2004,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1997,9 +2015,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2007,9 +2026,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2017,9 +2037,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2027,9 +2048,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2037,9 +2059,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2047,9 +2070,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {23})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -2057,9 +2081,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2068,9 +2093,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1884,9 +1884,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1894,9 +1895,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1904,9 +1906,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1914,9 +1917,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1924,9 +1928,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1934,9 +1939,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1944,9 +1950,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1954,9 +1961,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1964,9 +1972,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1974,9 +1983,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1984,9 +1994,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1994,9 +2005,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2004,9 +2016,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2014,9 +2027,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2024,9 +2038,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2034,9 +2049,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2044,9 +2060,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2054,9 +2071,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2064,9 +2082,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2074,9 +2093,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2084,9 +2104,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2094,9 +2115,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2104,9 +2126,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2114,9 +2137,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {23})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -2124,9 +2148,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T25, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {24})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T25, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -2134,9 +2159,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2145,9 +2171,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
@@ -195,9 +195,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -206,9 +207,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
@@ -327,9 +327,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -337,9 +338,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -347,9 +349,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1}, behavior)
     End Function
 
     ''' <summary>
@@ -357,9 +360,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -368,9 +372,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
@@ -384,9 +384,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -394,9 +395,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -404,9 +406,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -414,9 +417,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2}, behavior)
     End Function
 
     ''' <summary>
@@ -424,9 +428,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -435,9 +440,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
@@ -423,9 +423,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -433,9 +434,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -443,9 +445,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -453,9 +456,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -463,9 +467,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3}, behavior)
     End Function
 
     ''' <summary>
@@ -473,9 +478,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -484,9 +490,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -480,9 +480,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -490,9 +491,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -500,9 +502,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -510,9 +513,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -520,9 +524,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -530,9 +535,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4}, behavior)
     End Function
 
     ''' <summary>
@@ -540,9 +546,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -551,9 +558,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -537,9 +537,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -547,9 +548,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -557,9 +559,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -567,9 +570,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -577,9 +581,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -587,9 +592,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -597,9 +603,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5}, behavior)
     End Function
 
     ''' <summary>
@@ -607,9 +614,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -618,9 +626,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -594,9 +594,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -604,9 +605,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -614,9 +616,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -624,9 +627,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -634,9 +638,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -644,9 +649,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -654,9 +660,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -664,9 +671,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5, 6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5, 6}, behavior)
     End Function
 
     ''' <summary>
@@ -674,9 +682,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -685,9 +694,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -651,9 +651,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -661,9 +662,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -671,9 +673,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -681,9 +684,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -691,9 +695,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -701,9 +706,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -711,9 +717,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -721,9 +728,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -731,9 +739,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -742,9 +751,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -708,9 +708,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -718,9 +719,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -728,9 +730,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -738,9 +741,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -748,9 +752,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -758,9 +763,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -768,9 +774,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -778,9 +785,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -788,9 +796,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -798,9 +807,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -809,9 +819,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -765,9 +765,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -775,9 +776,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -785,9 +787,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -795,9 +798,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -805,9 +809,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -815,9 +820,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -825,9 +831,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -835,9 +842,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -845,9 +853,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -855,9 +864,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -865,9 +875,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -876,9 +887,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -822,9 +822,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -832,9 +833,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -842,9 +844,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -852,9 +855,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -862,9 +866,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -872,9 +877,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -882,9 +888,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -892,9 +899,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -902,9 +910,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -912,9 +921,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -922,9 +932,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -932,9 +943,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -943,9 +955,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -879,9 +879,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -889,9 +890,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -899,9 +901,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -909,9 +912,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -919,9 +923,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -929,9 +934,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -939,9 +945,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -949,9 +956,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -959,9 +967,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -969,9 +978,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -979,9 +989,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -989,9 +1000,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -999,9 +1011,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1010,9 +1023,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -936,9 +936,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -946,9 +947,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -956,9 +958,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -966,9 +969,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -976,9 +980,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -986,9 +991,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -996,9 +1002,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1006,9 +1013,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1016,9 +1024,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1026,9 +1035,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1036,9 +1046,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1046,9 +1057,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1056,9 +1068,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1066,9 +1079,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1077,9 +1091,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -993,9 +993,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1003,9 +1004,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1013,9 +1015,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1023,9 +1026,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1033,9 +1037,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1043,9 +1048,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1053,9 +1059,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1063,9 +1070,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1073,9 +1081,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1083,9 +1092,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1093,9 +1103,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1103,9 +1114,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1113,9 +1125,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1123,9 +1136,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1133,9 +1147,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1144,9 +1159,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -1050,9 +1050,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1060,9 +1061,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1070,9 +1072,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1080,9 +1083,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1090,9 +1094,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1100,9 +1105,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1110,9 +1116,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1120,9 +1127,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1130,9 +1138,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1140,9 +1149,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1150,9 +1160,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1160,9 +1171,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1170,9 +1182,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1180,9 +1193,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1190,9 +1204,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1200,9 +1215,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1211,9 +1227,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -1107,9 +1107,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1117,9 +1118,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1127,9 +1129,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1137,9 +1140,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1147,9 +1151,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1157,9 +1162,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1167,9 +1173,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1177,9 +1184,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1187,9 +1195,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1197,9 +1206,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1207,9 +1217,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1217,9 +1228,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1227,9 +1239,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1237,9 +1250,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1247,9 +1261,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1257,9 +1272,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1267,9 +1283,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1278,9 +1295,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -1164,9 +1164,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1174,9 +1175,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1184,9 +1186,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1194,9 +1197,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1204,9 +1208,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1214,9 +1219,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1224,9 +1230,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1234,9 +1241,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1244,9 +1252,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1254,9 +1263,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1264,9 +1274,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1274,9 +1285,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1284,9 +1296,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1294,9 +1307,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1304,9 +1318,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1314,9 +1329,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1324,9 +1340,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1334,9 +1351,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1345,9 +1363,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -1221,9 +1221,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1231,9 +1232,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1241,9 +1243,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1251,9 +1254,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1261,9 +1265,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1271,9 +1276,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1281,9 +1287,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1291,9 +1298,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1301,9 +1309,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1311,9 +1320,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1321,9 +1331,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1331,9 +1342,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1341,9 +1353,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1351,9 +1364,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1361,9 +1375,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1371,9 +1386,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1381,9 +1397,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1391,9 +1408,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1401,9 +1419,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1412,9 +1431,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -1278,9 +1278,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1288,9 +1289,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1298,9 +1300,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1308,9 +1311,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1318,9 +1322,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1328,9 +1333,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1338,9 +1344,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1348,9 +1355,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1358,9 +1366,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1368,9 +1377,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1378,9 +1388,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1388,9 +1399,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1398,9 +1410,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1408,9 +1421,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1418,9 +1432,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1428,9 +1443,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1438,9 +1454,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1448,9 +1465,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1458,9 +1476,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1468,9 +1487,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1479,9 +1499,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -1335,9 +1335,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1345,9 +1346,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1355,9 +1357,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1365,9 +1368,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1375,9 +1379,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1385,9 +1390,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1395,9 +1401,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1405,9 +1412,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1415,9 +1423,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1425,9 +1434,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1435,9 +1445,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1445,9 +1456,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1455,9 +1467,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1465,9 +1478,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1475,9 +1489,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1485,9 +1500,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1495,9 +1511,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1505,9 +1522,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1515,9 +1533,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1525,9 +1544,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1535,9 +1555,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1546,9 +1567,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -1392,9 +1392,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1402,9 +1403,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1412,9 +1414,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1422,9 +1425,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1432,9 +1436,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1442,9 +1447,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1452,9 +1458,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1462,9 +1469,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1472,9 +1480,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1482,9 +1491,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1492,9 +1502,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1502,9 +1513,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1512,9 +1524,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1522,9 +1535,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1532,9 +1546,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1542,9 +1557,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1552,9 +1568,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1562,9 +1579,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1572,9 +1590,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1582,9 +1601,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1592,9 +1612,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1602,9 +1623,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1613,9 +1635,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -1449,9 +1449,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1459,9 +1460,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1469,9 +1471,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1479,9 +1482,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1489,9 +1493,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1499,9 +1504,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1509,9 +1515,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1519,9 +1526,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1529,9 +1537,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1539,9 +1548,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1549,9 +1559,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1559,9 +1570,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1569,9 +1581,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1579,9 +1592,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1589,9 +1603,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1599,9 +1614,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1609,9 +1625,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1619,9 +1636,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1629,9 +1647,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1639,9 +1658,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1649,9 +1669,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1659,9 +1680,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1669,9 +1691,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1680,9 +1703,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -1506,9 +1506,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1516,9 +1517,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1526,9 +1528,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1536,9 +1539,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1546,9 +1550,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1556,9 +1561,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1566,9 +1572,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1576,9 +1583,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1586,9 +1594,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1596,9 +1605,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1606,9 +1616,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1616,9 +1627,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1626,9 +1638,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1636,9 +1649,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1646,9 +1660,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1656,9 +1671,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1666,9 +1682,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1676,9 +1693,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1686,9 +1704,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1696,9 +1715,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1706,9 +1726,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1716,9 +1737,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1726,9 +1748,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1736,9 +1759,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1747,9 +1771,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -1563,9 +1563,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1573,9 +1574,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1583,9 +1585,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1593,9 +1596,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1603,9 +1607,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1613,9 +1618,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1623,9 +1629,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1633,9 +1640,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1643,9 +1651,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1653,9 +1662,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1663,9 +1673,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1673,9 +1684,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1683,9 +1695,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1693,9 +1706,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1703,9 +1717,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1713,9 +1728,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1723,9 +1739,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1733,9 +1750,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1743,9 +1761,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1753,9 +1772,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1763,9 +1783,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1773,9 +1794,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1783,9 +1805,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1793,9 +1816,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {23})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -1803,9 +1827,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1814,9 +1839,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1620,9 +1620,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1630,9 +1631,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1640,9 +1642,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1650,9 +1653,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1660,9 +1664,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1670,9 +1675,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1680,9 +1686,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1690,9 +1697,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1700,9 +1708,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1710,9 +1719,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1720,9 +1730,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1730,9 +1741,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1740,9 +1752,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1750,9 +1763,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1760,9 +1774,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1770,9 +1785,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1780,9 +1796,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1790,9 +1807,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1800,9 +1818,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1810,9 +1829,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1820,9 +1840,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1830,9 +1851,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1840,9 +1862,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1850,9 +1873,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {23})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -1860,9 +1884,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T25, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {24})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T25, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -1870,9 +1895,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1881,9 +1907,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
@@ -187,9 +187,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -198,9 +199,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
@@ -319,9 +319,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -329,9 +330,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -339,9 +341,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1}, behavior)
     End Function
 
     ''' <summary>
@@ -349,9 +352,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -360,9 +364,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
@@ -376,9 +376,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -386,9 +387,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -396,9 +398,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -406,9 +409,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2}, behavior)
     End Function
 
     ''' <summary>
@@ -416,9 +420,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -427,9 +432,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
@@ -415,9 +415,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -425,9 +426,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -435,9 +437,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -445,9 +448,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -455,9 +459,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3}, behavior)
     End Function
 
     ''' <summary>
@@ -465,9 +470,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -476,9 +482,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -472,9 +472,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -482,9 +483,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -492,9 +494,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -502,9 +505,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -512,9 +516,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -522,9 +527,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4}, behavior)
     End Function
 
     ''' <summary>
@@ -532,9 +538,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -543,9 +550,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -529,9 +529,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -539,9 +540,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -549,9 +551,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -559,9 +562,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -569,9 +573,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -579,9 +584,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -589,9 +595,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5}, behavior)
     End Function
 
     ''' <summary>
@@ -599,9 +606,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -610,9 +618,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -586,9 +586,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -596,9 +597,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -606,9 +608,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -616,9 +619,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -626,9 +630,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -636,9 +641,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -646,9 +652,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -656,9 +663,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5, 6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5, 6}, behavior)
     End Function
 
     ''' <summary>
@@ -666,9 +674,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -677,9 +686,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -643,9 +643,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -653,9 +654,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -663,9 +665,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -673,9 +676,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -683,9 +687,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -693,9 +698,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -703,9 +709,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -713,9 +720,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -723,9 +731,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -734,9 +743,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -700,9 +700,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -710,9 +711,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -720,9 +722,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -730,9 +733,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -740,9 +744,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -750,9 +755,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -760,9 +766,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -770,9 +777,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -780,9 +788,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -790,9 +799,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -801,9 +811,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -757,9 +757,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -767,9 +768,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -777,9 +779,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -787,9 +790,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -797,9 +801,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -807,9 +812,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -817,9 +823,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -827,9 +834,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -837,9 +845,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -847,9 +856,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -857,9 +867,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -868,9 +879,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -814,9 +814,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -824,9 +825,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -834,9 +836,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -844,9 +847,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -854,9 +858,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -864,9 +869,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -874,9 +880,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -884,9 +891,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -894,9 +902,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -904,9 +913,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -914,9 +924,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -924,9 +935,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -935,9 +947,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -871,9 +871,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -881,9 +882,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -891,9 +893,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -901,9 +904,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -911,9 +915,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -921,9 +926,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -931,9 +937,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -941,9 +948,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -951,9 +959,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -961,9 +970,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -971,9 +981,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -981,9 +992,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -991,9 +1003,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1002,9 +1015,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -928,9 +928,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -938,9 +939,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -948,9 +950,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -958,9 +961,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -968,9 +972,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -978,9 +983,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -988,9 +994,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -998,9 +1005,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1008,9 +1016,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1018,9 +1027,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1028,9 +1038,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1038,9 +1049,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1048,9 +1060,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1058,9 +1071,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1069,9 +1083,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -985,9 +985,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -995,9 +996,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1005,9 +1007,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1015,9 +1018,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1025,9 +1029,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1035,9 +1040,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1045,9 +1051,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1055,9 +1062,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1065,9 +1073,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1075,9 +1084,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1085,9 +1095,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1095,9 +1106,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1105,9 +1117,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1115,9 +1128,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1125,9 +1139,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1136,9 +1151,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -1042,9 +1042,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1052,9 +1053,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1062,9 +1064,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1072,9 +1075,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1082,9 +1086,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1092,9 +1097,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1102,9 +1108,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1112,9 +1119,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1122,9 +1130,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1132,9 +1141,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1142,9 +1152,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1152,9 +1163,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1162,9 +1174,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1172,9 +1185,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1182,9 +1196,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1192,9 +1207,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1203,9 +1219,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -1099,9 +1099,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1109,9 +1110,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1119,9 +1121,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1129,9 +1132,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1139,9 +1143,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1149,9 +1154,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1159,9 +1165,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1169,9 +1176,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1179,9 +1187,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1189,9 +1198,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1199,9 +1209,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1209,9 +1220,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1219,9 +1231,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1229,9 +1242,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1239,9 +1253,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1249,9 +1264,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1259,9 +1275,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1270,9 +1287,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -1156,9 +1156,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1166,9 +1167,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1176,9 +1178,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1186,9 +1189,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1196,9 +1200,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1206,9 +1211,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1216,9 +1222,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1226,9 +1233,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1236,9 +1244,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1246,9 +1255,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1256,9 +1266,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1266,9 +1277,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1276,9 +1288,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1286,9 +1299,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1296,9 +1310,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1306,9 +1321,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1316,9 +1332,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1326,9 +1343,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1337,9 +1355,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -1213,9 +1213,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1223,9 +1224,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1233,9 +1235,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1243,9 +1246,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1253,9 +1257,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1263,9 +1268,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1273,9 +1279,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1283,9 +1290,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1293,9 +1301,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1303,9 +1312,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1313,9 +1323,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1323,9 +1334,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1333,9 +1345,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1343,9 +1356,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1353,9 +1367,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1363,9 +1378,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1373,9 +1389,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1383,9 +1400,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1393,9 +1411,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1404,9 +1423,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -1270,9 +1270,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1280,9 +1281,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1290,9 +1292,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1300,9 +1303,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1310,9 +1314,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1320,9 +1325,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1330,9 +1336,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1340,9 +1347,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1350,9 +1358,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1360,9 +1369,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1370,9 +1380,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1380,9 +1391,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1390,9 +1402,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1400,9 +1413,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1410,9 +1424,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1420,9 +1435,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1430,9 +1446,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1440,9 +1457,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1450,9 +1468,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1460,9 +1479,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1471,9 +1491,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -1327,9 +1327,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1337,9 +1338,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1347,9 +1349,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1357,9 +1360,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1367,9 +1371,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1377,9 +1382,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1387,9 +1393,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1397,9 +1404,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1407,9 +1415,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1417,9 +1426,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1427,9 +1437,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1437,9 +1448,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1447,9 +1459,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1457,9 +1470,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1467,9 +1481,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1477,9 +1492,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1487,9 +1503,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1497,9 +1514,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1507,9 +1525,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1517,9 +1536,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1527,9 +1547,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1538,9 +1559,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -1384,9 +1384,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1394,9 +1395,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1404,9 +1406,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1414,9 +1417,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1424,9 +1428,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1434,9 +1439,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1444,9 +1450,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1454,9 +1461,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1464,9 +1472,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1474,9 +1483,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1484,9 +1494,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1494,9 +1505,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1504,9 +1516,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1514,9 +1527,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1524,9 +1538,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1534,9 +1549,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1544,9 +1560,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1554,9 +1571,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1564,9 +1582,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1574,9 +1593,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1584,9 +1604,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1594,9 +1615,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1605,9 +1627,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -1441,9 +1441,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1451,9 +1452,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1461,9 +1463,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1471,9 +1474,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1481,9 +1485,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1491,9 +1496,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1501,9 +1507,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1511,9 +1518,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1521,9 +1529,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1531,9 +1540,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1541,9 +1551,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1551,9 +1562,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1561,9 +1573,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1571,9 +1584,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1581,9 +1595,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1591,9 +1606,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1601,9 +1617,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1611,9 +1628,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1621,9 +1639,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1631,9 +1650,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1641,9 +1661,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1651,9 +1672,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1661,9 +1683,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1672,9 +1695,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -1498,9 +1498,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1508,9 +1509,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1518,9 +1520,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1528,9 +1531,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1538,9 +1542,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1548,9 +1553,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1558,9 +1564,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1568,9 +1575,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1578,9 +1586,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1588,9 +1597,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1598,9 +1608,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1608,9 +1619,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1618,9 +1630,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1628,9 +1641,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1638,9 +1652,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1648,9 +1663,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1658,9 +1674,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1668,9 +1685,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1678,9 +1696,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1688,9 +1707,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1698,9 +1718,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1708,9 +1729,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1718,9 +1740,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1728,9 +1751,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1739,9 +1763,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -1555,9 +1555,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1565,9 +1566,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1575,9 +1577,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1585,9 +1588,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1595,9 +1599,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1605,9 +1610,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1615,9 +1621,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1625,9 +1632,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1635,9 +1643,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1645,9 +1654,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1655,9 +1665,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1665,9 +1676,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1675,9 +1687,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1685,9 +1698,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1695,9 +1709,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1705,9 +1720,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1715,9 +1731,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1725,9 +1742,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1735,9 +1753,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1745,9 +1764,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1755,9 +1775,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1765,9 +1786,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1775,9 +1797,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1785,9 +1808,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {23})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -1795,9 +1819,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1806,9 +1831,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1612,9 +1612,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1622,9 +1623,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1632,9 +1634,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1642,9 +1645,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1652,9 +1656,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1662,9 +1667,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1672,9 +1678,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1682,9 +1689,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1692,9 +1700,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1702,9 +1711,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1712,9 +1722,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1722,9 +1733,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1732,9 +1744,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1742,9 +1755,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1752,9 +1766,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1762,9 +1777,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1772,9 +1788,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1782,9 +1799,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1792,9 +1810,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1802,9 +1821,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1812,9 +1832,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1822,9 +1843,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1832,9 +1854,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1842,9 +1865,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {23})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -1852,9 +1876,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T25, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {24})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T25, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -1862,9 +1887,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1873,9 +1899,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpression.vb
@@ -45,9 +45,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -56,9 +57,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2.vb
@@ -47,9 +47,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -57,9 +58,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -67,9 +69,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1}, behavior)
     End Function
 
     ''' <summary>
@@ -77,9 +80,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -88,9 +92,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3.vb
@@ -48,9 +48,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -58,9 +59,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -68,9 +70,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -78,9 +81,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2}, behavior)
     End Function
 
     ''' <summary>
@@ -88,9 +92,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -99,9 +104,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4.vb
@@ -49,9 +49,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -59,9 +60,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -69,9 +71,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -79,9 +82,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -89,9 +93,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3}, behavior)
     End Function
 
     ''' <summary>
@@ -99,9 +104,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -110,9 +116,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -50,9 +50,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -60,9 +61,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -70,9 +72,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -80,9 +83,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -90,9 +94,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -100,9 +105,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4}, behavior)
     End Function
 
     ''' <summary>
@@ -110,9 +116,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -121,9 +128,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -51,9 +51,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -61,9 +62,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -71,9 +73,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -81,9 +84,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -91,9 +95,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -101,9 +106,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -111,9 +117,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5}, behavior)
     End Function
 
     ''' <summary>
@@ -121,9 +128,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -132,9 +140,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -52,9 +52,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -62,9 +63,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -72,9 +74,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -82,9 +85,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -92,9 +96,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -102,9 +107,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -112,9 +118,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -122,9 +129,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5, 6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5, 6}, behavior)
     End Function
 
     ''' <summary>
@@ -132,9 +140,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -143,9 +152,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -53,9 +53,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -63,9 +64,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -73,9 +75,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -83,9 +86,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -93,9 +97,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -103,9 +108,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -113,9 +119,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -123,9 +130,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -133,9 +141,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -144,9 +153,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -54,9 +54,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -64,9 +65,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -74,9 +76,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -84,9 +87,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -94,9 +98,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -104,9 +109,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -114,9 +120,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -124,9 +131,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -134,9 +142,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -144,9 +153,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -155,9 +165,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -55,9 +55,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -65,9 +66,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -75,9 +77,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -85,9 +88,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -95,9 +99,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -105,9 +110,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -115,9 +121,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -125,9 +132,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -135,9 +143,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -145,9 +154,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -155,9 +165,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -166,9 +177,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -56,9 +56,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -66,9 +67,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -76,9 +78,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -86,9 +89,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -96,9 +100,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -106,9 +111,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -116,9 +122,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -126,9 +133,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -136,9 +144,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -146,9 +155,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -156,9 +166,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -166,9 +177,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -177,9 +189,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -57,9 +57,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -67,9 +68,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -77,9 +79,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -87,9 +90,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -97,9 +101,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -107,9 +112,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -117,9 +123,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -127,9 +134,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -137,9 +145,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -147,9 +156,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -157,9 +167,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -167,9 +178,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -177,9 +189,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -188,9 +201,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -58,9 +58,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -68,9 +69,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -78,9 +80,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -88,9 +91,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -98,9 +102,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -108,9 +113,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -118,9 +124,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -128,9 +135,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -138,9 +146,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -148,9 +157,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -158,9 +168,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -168,9 +179,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -178,9 +190,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -188,9 +201,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -199,9 +213,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -59,9 +59,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -69,9 +70,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -79,9 +81,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -89,9 +92,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -99,9 +103,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -109,9 +114,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -119,9 +125,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -129,9 +136,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -139,9 +147,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -149,9 +158,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -159,9 +169,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -169,9 +180,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -179,9 +191,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -189,9 +202,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -199,9 +213,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -210,9 +225,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -60,9 +60,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -70,9 +71,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -80,9 +82,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -90,9 +93,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -100,9 +104,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -110,9 +115,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -120,9 +126,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -130,9 +137,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -140,9 +148,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -150,9 +159,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -160,9 +170,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -170,9 +181,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -180,9 +192,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -190,9 +203,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -200,9 +214,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -210,9 +225,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -221,9 +237,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -61,9 +61,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -71,9 +72,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -81,9 +83,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -91,9 +94,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -101,9 +105,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -111,9 +116,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -121,9 +127,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -131,9 +138,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -141,9 +149,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -151,9 +160,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -161,9 +171,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -171,9 +182,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -181,9 +193,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -191,9 +204,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -201,9 +215,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -211,9 +226,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -221,9 +237,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -232,9 +249,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -62,9 +62,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -72,9 +73,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -82,9 +84,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -92,9 +95,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -102,9 +106,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -112,9 +117,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -122,9 +128,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -132,9 +139,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -142,9 +150,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -152,9 +161,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -162,9 +172,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -172,9 +183,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -182,9 +194,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -192,9 +205,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -202,9 +216,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -212,9 +227,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -222,9 +238,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -232,9 +249,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -243,9 +261,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -63,9 +63,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -73,9 +74,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -83,9 +85,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -93,9 +96,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -103,9 +107,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -113,9 +118,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -123,9 +129,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -133,9 +140,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -143,9 +151,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -153,9 +162,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -163,9 +173,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -173,9 +184,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -183,9 +195,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -193,9 +206,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -203,9 +217,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -213,9 +228,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -223,9 +239,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -233,9 +250,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -243,9 +261,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -254,9 +273,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -64,9 +64,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -74,9 +75,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -84,9 +86,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -94,9 +97,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -104,9 +108,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -114,9 +119,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -124,9 +130,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -134,9 +141,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -144,9 +152,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -154,9 +163,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -164,9 +174,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -174,9 +185,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -184,9 +196,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -194,9 +207,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -204,9 +218,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -214,9 +229,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -224,9 +240,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -234,9 +251,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -244,9 +262,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -254,9 +273,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -265,9 +285,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -65,9 +65,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -75,9 +76,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -85,9 +87,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -95,9 +98,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -105,9 +109,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -115,9 +120,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -125,9 +131,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -135,9 +142,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -145,9 +153,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -155,9 +164,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -165,9 +175,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -175,9 +186,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -185,9 +197,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -195,9 +208,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -205,9 +219,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -215,9 +230,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -225,9 +241,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -235,9 +252,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -245,9 +263,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -255,9 +274,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -265,9 +285,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -276,9 +297,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -66,9 +66,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -76,9 +77,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -86,9 +88,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -96,9 +99,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -106,9 +110,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -116,9 +121,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -126,9 +132,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -136,9 +143,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -146,9 +154,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -156,9 +165,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -166,9 +176,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -176,9 +187,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -186,9 +198,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -196,9 +209,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -206,9 +220,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -216,9 +231,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -226,9 +242,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -236,9 +253,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -246,9 +264,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -256,9 +275,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -266,9 +286,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -276,9 +297,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -287,9 +309,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -67,9 +67,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -77,9 +78,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -87,9 +89,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -97,9 +100,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -107,9 +111,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -117,9 +122,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -127,9 +133,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -137,9 +144,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -147,9 +155,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -157,9 +166,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -167,9 +177,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -177,9 +188,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -187,9 +199,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -197,9 +210,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -207,9 +221,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -217,9 +232,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -227,9 +243,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -237,9 +254,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -247,9 +265,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -257,9 +276,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -267,9 +287,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -277,9 +298,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -287,9 +309,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -298,9 +321,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -68,9 +68,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -78,9 +79,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -88,9 +90,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -98,9 +101,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -108,9 +112,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -118,9 +123,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -128,9 +134,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -138,9 +145,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -148,9 +156,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -158,9 +167,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -168,9 +178,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -178,9 +189,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -188,9 +200,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -198,9 +211,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -208,9 +222,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -218,9 +233,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -228,9 +244,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -238,9 +255,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -248,9 +266,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -258,9 +277,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -268,9 +288,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -278,9 +299,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -288,9 +310,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -298,9 +321,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -309,9 +333,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -69,9 +69,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -79,9 +80,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -89,9 +91,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -99,9 +102,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -109,9 +113,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -119,9 +124,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -129,9 +135,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -139,9 +146,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -149,9 +157,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -159,9 +168,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -169,9 +179,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -179,9 +190,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -189,9 +201,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -199,9 +212,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -209,9 +223,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -219,9 +234,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -229,9 +245,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -239,9 +256,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -249,9 +267,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -259,9 +278,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -269,9 +289,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -279,9 +300,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -289,9 +311,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -299,9 +322,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {23})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -309,9 +333,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -320,9 +345,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -70,9 +70,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -80,9 +81,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -90,9 +92,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -100,9 +103,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -110,9 +114,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -120,9 +125,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -130,9 +136,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -140,9 +147,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -150,9 +158,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -160,9 +169,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -170,9 +180,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -180,9 +191,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -190,9 +202,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -200,9 +213,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -210,9 +224,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -220,9 +235,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -230,9 +246,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -240,9 +257,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -250,9 +268,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -260,9 +279,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -270,9 +290,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -280,9 +301,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -290,9 +312,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -300,9 +323,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {23})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -310,9 +334,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T25, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {24})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T25, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -320,9 +345,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -331,9 +357,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpression.vb
@@ -147,9 +147,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -158,9 +159,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2.vb
@@ -225,9 +225,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -235,9 +236,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -245,9 +247,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1}, behavior)
     End Function
 
     ''' <summary>
@@ -255,9 +258,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -266,9 +270,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3.vb
@@ -264,9 +264,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -274,9 +275,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -284,9 +286,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -294,9 +297,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2}, behavior)
     End Function
 
     ''' <summary>
@@ -304,9 +308,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -315,9 +320,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4.vb
@@ -303,9 +303,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -313,9 +314,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -323,9 +325,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -333,9 +336,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -343,9 +347,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3}, behavior)
     End Function
 
     ''' <summary>
@@ -353,9 +358,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -364,9 +370,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -342,9 +342,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -352,9 +353,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -362,9 +364,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -372,9 +375,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -382,9 +386,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -392,9 +397,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4}, behavior)
     End Function
 
     ''' <summary>
@@ -402,9 +408,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -413,9 +420,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -381,9 +381,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -391,9 +392,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -401,9 +403,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -411,9 +414,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -421,9 +425,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -431,9 +436,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -441,9 +447,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5}, behavior)
     End Function
 
     ''' <summary>
@@ -451,9 +458,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -462,9 +470,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -420,9 +420,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -430,9 +431,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -440,9 +442,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -450,9 +453,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -460,9 +464,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -470,9 +475,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -480,9 +486,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -490,9 +497,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5, 6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5, 6}, behavior)
     End Function
 
     ''' <summary>
@@ -500,9 +508,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -511,9 +520,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -459,9 +459,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -469,9 +470,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -479,9 +481,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -489,9 +492,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -499,9 +503,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -509,9 +514,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -519,9 +525,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -529,9 +536,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -539,9 +547,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -550,9 +559,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -498,9 +498,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -508,9 +509,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -518,9 +520,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -528,9 +531,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -538,9 +542,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -548,9 +553,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -558,9 +564,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -568,9 +575,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -578,9 +586,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -588,9 +597,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -599,9 +609,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -537,9 +537,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -547,9 +548,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -557,9 +559,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -567,9 +570,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -577,9 +581,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -587,9 +592,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -597,9 +603,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -607,9 +614,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -617,9 +625,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -627,9 +636,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -637,9 +647,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -648,9 +659,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -576,9 +576,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -586,9 +587,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -596,9 +598,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -606,9 +609,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -616,9 +620,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -626,9 +631,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -636,9 +642,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -646,9 +653,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -656,9 +664,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -666,9 +675,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -676,9 +686,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -686,9 +697,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -697,9 +709,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -615,9 +615,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -625,9 +626,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -635,9 +637,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -645,9 +648,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -655,9 +659,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -665,9 +670,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -675,9 +681,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -685,9 +692,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -695,9 +703,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -705,9 +714,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -715,9 +725,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -725,9 +736,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -735,9 +747,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -746,9 +759,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -654,9 +654,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -664,9 +665,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -674,9 +676,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -684,9 +687,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -694,9 +698,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -704,9 +709,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -714,9 +720,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -724,9 +731,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -734,9 +742,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -744,9 +753,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -754,9 +764,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -764,9 +775,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -774,9 +786,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -784,9 +797,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -795,9 +809,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -693,9 +693,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -703,9 +704,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -713,9 +715,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -723,9 +726,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -733,9 +737,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -743,9 +748,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -753,9 +759,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -763,9 +770,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -773,9 +781,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -783,9 +792,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -793,9 +803,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -803,9 +814,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -813,9 +825,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -823,9 +836,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -833,9 +847,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -844,9 +859,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -732,9 +732,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -742,9 +743,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -752,9 +754,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -762,9 +765,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -772,9 +776,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -782,9 +787,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -792,9 +798,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -802,9 +809,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -812,9 +820,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -822,9 +831,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -832,9 +842,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -842,9 +853,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -852,9 +864,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -862,9 +875,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -872,9 +886,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -882,9 +897,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -893,9 +909,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -771,9 +771,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -781,9 +782,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -791,9 +793,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -801,9 +804,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -811,9 +815,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -821,9 +826,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -831,9 +837,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -841,9 +848,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -851,9 +859,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -861,9 +870,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -871,9 +881,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -881,9 +892,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -891,9 +903,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -901,9 +914,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -911,9 +925,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -921,9 +936,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -931,9 +947,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -942,9 +959,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -810,9 +810,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -820,9 +821,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -830,9 +832,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -840,9 +843,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -850,9 +854,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -860,9 +865,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -870,9 +876,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -880,9 +887,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -890,9 +898,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -900,9 +909,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -910,9 +920,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -920,9 +931,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -930,9 +942,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -940,9 +953,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -950,9 +964,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -960,9 +975,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -970,9 +986,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -980,9 +997,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -991,9 +1009,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -849,9 +849,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -859,9 +860,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -869,9 +871,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -879,9 +882,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -889,9 +893,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -899,9 +904,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -909,9 +915,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -919,9 +926,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -929,9 +937,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -939,9 +948,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -949,9 +959,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -959,9 +970,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -969,9 +981,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -979,9 +992,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -989,9 +1003,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -999,9 +1014,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1009,9 +1025,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1019,9 +1036,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1029,9 +1047,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1040,9 +1059,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -888,9 +888,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -898,9 +899,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -908,9 +910,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -918,9 +921,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -928,9 +932,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -938,9 +943,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -948,9 +954,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -958,9 +965,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -968,9 +976,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -978,9 +987,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -988,9 +998,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -998,9 +1009,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1008,9 +1020,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1018,9 +1031,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1028,9 +1042,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1038,9 +1053,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1048,9 +1064,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1058,9 +1075,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1068,9 +1086,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1078,9 +1097,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1089,9 +1109,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -927,9 +927,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -937,9 +938,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -947,9 +949,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -957,9 +960,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -967,9 +971,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -977,9 +982,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -987,9 +993,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -997,9 +1004,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1007,9 +1015,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1017,9 +1026,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1027,9 +1037,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1037,9 +1048,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1047,9 +1059,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1057,9 +1070,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1067,9 +1081,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1077,9 +1092,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1087,9 +1103,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1097,9 +1114,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1107,9 +1125,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1117,9 +1136,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1127,9 +1147,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1138,9 +1159,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -966,9 +966,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -976,9 +977,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -986,9 +988,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -996,9 +999,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1006,9 +1010,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1016,9 +1021,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1026,9 +1032,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1036,9 +1043,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1046,9 +1054,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1056,9 +1065,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1066,9 +1076,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1076,9 +1087,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1086,9 +1098,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1096,9 +1109,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1106,9 +1120,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1116,9 +1131,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1126,9 +1142,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1136,9 +1153,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1146,9 +1164,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1156,9 +1175,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1166,9 +1186,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1176,9 +1197,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1187,9 +1209,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -1005,9 +1005,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1015,9 +1016,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1025,9 +1027,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1035,9 +1038,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1045,9 +1049,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1055,9 +1060,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1065,9 +1071,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1075,9 +1082,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1085,9 +1093,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1095,9 +1104,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1105,9 +1115,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1115,9 +1126,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1125,9 +1137,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1135,9 +1148,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1145,9 +1159,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1155,9 +1170,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1165,9 +1181,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1175,9 +1192,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1185,9 +1203,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1195,9 +1214,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1205,9 +1225,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1215,9 +1236,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1225,9 +1247,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1236,9 +1259,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -1044,9 +1044,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1054,9 +1055,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1064,9 +1066,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1074,9 +1077,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1084,9 +1088,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1094,9 +1099,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1104,9 +1110,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1114,9 +1121,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1124,9 +1132,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1134,9 +1143,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1144,9 +1154,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1154,9 +1165,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1164,9 +1176,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1174,9 +1187,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1184,9 +1198,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1194,9 +1209,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1204,9 +1220,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1214,9 +1231,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1224,9 +1242,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1234,9 +1253,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1244,9 +1264,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1254,9 +1275,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1264,9 +1286,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1274,9 +1297,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1285,9 +1309,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -1083,9 +1083,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1093,9 +1094,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1103,9 +1105,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1113,9 +1116,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1123,9 +1127,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1133,9 +1138,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1143,9 +1149,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1153,9 +1160,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1163,9 +1171,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1173,9 +1182,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1183,9 +1193,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1193,9 +1204,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1203,9 +1215,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1213,9 +1226,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1223,9 +1237,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1233,9 +1248,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1243,9 +1259,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1253,9 +1270,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1263,9 +1281,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1273,9 +1292,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1283,9 +1303,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1293,9 +1314,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1303,9 +1325,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1313,9 +1336,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {23})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -1323,9 +1347,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1334,9 +1359,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1122,9 +1122,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1132,9 +1133,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1142,9 +1144,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1152,9 +1155,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1162,9 +1166,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1172,9 +1177,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1182,9 +1188,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1192,9 +1199,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1202,9 +1210,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1212,9 +1221,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1222,9 +1232,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1232,9 +1243,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1242,9 +1254,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1252,9 +1265,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1262,9 +1276,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1272,9 +1287,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1282,9 +1298,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1292,9 +1309,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1302,9 +1320,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1312,9 +1331,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1322,9 +1342,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1332,9 +1353,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1342,9 +1364,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1352,9 +1375,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {23})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -1362,9 +1386,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T25, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {24})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T25, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -1372,9 +1397,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1383,9 +1409,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
@@ -34,10 +34,9 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="context"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
-    Friend Sub New(context As DbContext, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)), behavior As NonModelEntityCreationBehavior)
+    Friend Sub New(context As DbContext, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)))
       MyBase.New(New SelectSqlExpressionBuilder(context), New QueryExecutor(context))
-      Me.Builder.SetMainTableSource(Me.Executor, tableSourceFactory, behavior)
+      Me.Builder.SetMainTableSource(Me.Executor, tableSourceFactory)
     End Sub
 
     ''' <summary>
@@ -55,10 +54,9 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="context"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
-    Friend Sub New(context As SubqueryContext, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)), behavior As NonModelEntityCreationBehavior)
+    Friend Sub New(context As SubqueryContext, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)))
       MyBase.New(New SelectSqlExpressionBuilder(context), context.Executor)
-      Me.Builder.SetMainTableSource(Me.Executor, tableSourceFactory, behavior)
+      Me.Builder.SetMainTableSource(Me.Executor, tableSourceFactory)
     End Sub
 
     ''' <summary>
@@ -137,10 +135,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -198,10 +195,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -259,10 +255,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -320,10 +315,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -361,10 +355,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -424,10 +417,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -652,9 +644,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -663,9 +656,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
@@ -77,10 +77,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -158,10 +157,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -239,10 +237,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -320,10 +317,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -361,10 +357,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -424,10 +419,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -813,9 +807,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -823,9 +818,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -833,9 +829,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1}, behavior)
     End Function
 
     ''' <summary>
@@ -843,9 +840,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -854,9 +852,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
@@ -78,10 +78,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -159,10 +158,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -240,10 +238,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -321,10 +318,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -362,10 +358,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -425,10 +420,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -880,9 +874,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -890,9 +885,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -900,9 +896,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -910,9 +907,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2}, behavior)
     End Function
 
     ''' <summary>
@@ -920,9 +918,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -931,9 +930,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
@@ -89,10 +89,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -180,10 +179,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -271,10 +269,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -362,10 +359,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -403,10 +399,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -466,10 +461,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -969,9 +963,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -979,9 +974,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -989,9 +985,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -999,9 +996,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1009,9 +1007,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3}, behavior)
     End Function
 
     ''' <summary>
@@ -1019,9 +1018,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1030,9 +1030,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
@@ -100,10 +100,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -201,10 +200,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -302,10 +300,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -403,10 +400,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -444,10 +440,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -507,10 +502,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1076,9 +1070,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1086,9 +1081,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1096,9 +1092,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1106,9 +1103,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1116,9 +1114,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1126,9 +1125,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4}, behavior)
     End Function
 
     ''' <summary>
@@ -1136,9 +1136,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1147,9 +1148,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -111,10 +111,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -222,10 +221,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -333,10 +331,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -444,10 +441,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -485,10 +481,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -548,10 +543,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1183,9 +1177,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1193,9 +1188,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1203,9 +1199,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1213,9 +1210,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1223,9 +1221,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1233,9 +1232,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1243,9 +1243,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5}, behavior)
     End Function
 
     ''' <summary>
@@ -1253,9 +1254,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1264,9 +1266,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -52,10 +52,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -103,10 +102,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -154,10 +152,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -205,10 +202,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -246,10 +242,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -309,10 +304,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1010,9 +1004,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1020,9 +1015,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1030,9 +1026,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1040,9 +1037,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1050,9 +1048,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1060,9 +1059,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1070,9 +1070,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1080,9 +1081,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5, 6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5, 6}, behavior)
     End Function
 
     ''' <summary>
@@ -1090,9 +1092,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1101,9 +1104,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -53,10 +53,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -104,10 +103,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -155,10 +153,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -206,10 +203,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -247,10 +243,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -310,10 +305,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1067,9 +1061,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1077,9 +1072,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1087,9 +1083,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1097,9 +1094,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1107,9 +1105,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1117,9 +1116,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1127,9 +1127,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1137,9 +1138,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1147,9 +1149,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1158,9 +1161,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -54,10 +54,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -105,10 +104,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -156,10 +154,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -207,10 +204,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -248,10 +244,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -311,10 +306,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1134,9 +1128,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1144,9 +1139,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1154,9 +1150,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1164,9 +1161,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1174,9 +1172,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1184,9 +1183,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1194,9 +1194,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1204,9 +1205,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1214,9 +1216,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1224,9 +1227,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1235,9 +1239,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -55,10 +55,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -106,10 +105,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -157,10 +155,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -208,10 +205,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -249,10 +245,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -312,10 +307,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1201,9 +1195,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1211,9 +1206,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1221,9 +1217,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1231,9 +1228,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1241,9 +1239,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1251,9 +1250,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1261,9 +1261,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1271,9 +1272,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1281,9 +1283,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1291,9 +1294,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1301,9 +1305,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1312,9 +1317,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -56,10 +56,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -107,10 +106,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -158,10 +156,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -209,10 +206,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -250,10 +246,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -313,10 +308,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1268,9 +1262,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1278,9 +1273,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1288,9 +1284,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1298,9 +1295,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1308,9 +1306,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1318,9 +1317,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1328,9 +1328,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1338,9 +1339,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1348,9 +1350,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1358,9 +1361,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1368,9 +1372,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1378,9 +1383,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1389,9 +1395,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -57,10 +57,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -108,10 +107,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -159,10 +157,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -210,10 +207,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -251,10 +247,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -314,10 +309,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1335,9 +1329,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1345,9 +1340,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1355,9 +1351,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1365,9 +1362,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1375,9 +1373,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1385,9 +1384,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1395,9 +1395,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1405,9 +1406,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1415,9 +1417,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1425,9 +1428,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1435,9 +1439,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1445,9 +1450,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1455,9 +1461,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1466,9 +1473,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -58,10 +58,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -109,10 +108,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -160,10 +158,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -211,10 +208,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -252,10 +248,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -315,10 +310,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1402,9 +1396,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1412,9 +1407,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1422,9 +1418,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1432,9 +1429,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1442,9 +1440,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1452,9 +1451,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1462,9 +1462,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1472,9 +1473,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1482,9 +1484,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1492,9 +1495,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1502,9 +1506,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1512,9 +1517,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1522,9 +1528,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1532,9 +1539,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1543,9 +1551,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -59,10 +59,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -110,10 +109,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -161,10 +159,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -212,10 +209,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -253,10 +249,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -316,10 +311,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1469,9 +1463,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1479,9 +1474,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1489,9 +1485,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1499,9 +1496,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1509,9 +1507,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1519,9 +1518,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1529,9 +1529,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1539,9 +1540,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1549,9 +1551,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1559,9 +1562,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1569,9 +1573,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1579,9 +1584,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1589,9 +1595,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1599,9 +1606,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1609,9 +1617,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1620,9 +1629,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -60,10 +60,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -111,10 +110,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -162,10 +160,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -213,10 +210,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -254,10 +250,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -317,10 +312,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1536,9 +1530,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1546,9 +1541,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1556,9 +1552,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1566,9 +1563,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1576,9 +1574,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1586,9 +1585,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1596,9 +1596,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1606,9 +1607,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1616,9 +1618,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1626,9 +1629,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1636,9 +1640,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1646,9 +1651,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1656,9 +1662,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1666,9 +1673,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1676,9 +1684,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1686,9 +1695,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1697,9 +1707,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -61,10 +61,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -112,10 +111,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -163,10 +161,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -214,10 +211,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -255,10 +251,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -318,10 +313,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1603,9 +1597,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1613,9 +1608,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1623,9 +1619,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1633,9 +1630,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1643,9 +1641,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1653,9 +1652,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1663,9 +1663,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1673,9 +1674,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1683,9 +1685,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1693,9 +1696,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1703,9 +1707,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1713,9 +1718,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1723,9 +1729,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1733,9 +1740,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1743,9 +1751,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1753,9 +1762,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1763,9 +1773,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1774,9 +1785,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -62,10 +62,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -113,10 +112,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -164,10 +162,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -215,10 +212,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -256,10 +252,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -319,10 +314,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1670,9 +1664,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1680,9 +1675,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1690,9 +1686,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1700,9 +1697,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1710,9 +1708,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1720,9 +1719,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1730,9 +1730,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1740,9 +1741,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1750,9 +1752,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1760,9 +1763,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1770,9 +1774,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1780,9 +1785,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1790,9 +1796,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1800,9 +1807,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1810,9 +1818,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1820,9 +1829,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1830,9 +1840,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1840,9 +1851,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1851,9 +1863,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -63,10 +63,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -114,10 +113,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -165,10 +163,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -216,10 +213,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -257,10 +253,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -320,10 +315,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1737,9 +1731,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1747,9 +1742,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1757,9 +1753,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1767,9 +1764,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1777,9 +1775,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1787,9 +1786,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1797,9 +1797,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1807,9 +1808,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1817,9 +1819,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1827,9 +1830,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1837,9 +1841,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1847,9 +1852,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1857,9 +1863,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1867,9 +1874,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1877,9 +1885,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1887,9 +1896,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1897,9 +1907,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1907,9 +1918,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1917,9 +1929,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1928,9 +1941,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -64,10 +64,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -115,10 +114,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -166,10 +164,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -217,10 +214,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -258,10 +254,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -321,10 +316,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1804,9 +1798,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1814,9 +1809,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1824,9 +1820,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1834,9 +1831,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1844,9 +1842,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1854,9 +1853,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1864,9 +1864,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1874,9 +1875,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1884,9 +1886,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1894,9 +1897,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1904,9 +1908,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1914,9 +1919,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1924,9 +1930,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1934,9 +1941,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1944,9 +1952,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1954,9 +1963,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1964,9 +1974,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1974,9 +1985,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1984,9 +1996,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1994,9 +2007,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2005,9 +2019,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -65,10 +65,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -116,10 +115,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -167,10 +165,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -218,10 +215,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -259,10 +255,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -322,10 +317,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1871,9 +1865,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1881,9 +1876,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1891,9 +1887,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1901,9 +1898,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1911,9 +1909,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1921,9 +1920,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1931,9 +1931,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1941,9 +1942,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1951,9 +1953,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1961,9 +1964,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1971,9 +1975,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1981,9 +1986,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1991,9 +1997,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2001,9 +2008,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2011,9 +2019,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2021,9 +2030,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2031,9 +2041,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2041,9 +2052,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2051,9 +2063,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2061,9 +2074,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2071,9 +2085,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2082,9 +2097,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -66,10 +66,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -117,10 +116,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -168,10 +166,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -219,10 +216,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -260,10 +256,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -323,10 +318,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -1938,9 +1932,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1948,9 +1943,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1958,9 +1954,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1968,9 +1965,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1978,9 +1976,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1988,9 +1987,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1998,9 +1998,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2008,9 +2009,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2018,9 +2020,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2028,9 +2031,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2038,9 +2042,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2048,9 +2053,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2058,9 +2064,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2068,9 +2075,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2078,9 +2086,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2088,9 +2097,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2098,9 +2108,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2108,9 +2119,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2118,9 +2130,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2128,9 +2141,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2138,9 +2152,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2148,9 +2163,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2159,9 +2175,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -67,10 +67,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -118,10 +117,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -169,10 +167,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -220,10 +217,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -261,10 +257,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -324,10 +319,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -2005,9 +1999,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2015,9 +2010,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2025,9 +2021,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2035,9 +2032,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2045,9 +2043,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2055,9 +2054,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2065,9 +2065,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2075,9 +2076,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2085,9 +2087,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2095,9 +2098,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2105,9 +2109,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2115,9 +2120,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2125,9 +2131,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2135,9 +2142,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2145,9 +2153,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2155,9 +2164,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2165,9 +2175,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2175,9 +2186,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2185,9 +2197,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2195,9 +2208,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2205,9 +2219,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2215,9 +2230,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2225,9 +2241,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2236,9 +2253,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -68,10 +68,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -119,10 +118,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -170,10 +168,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -221,10 +218,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -262,10 +258,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -325,10 +320,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -2072,9 +2066,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2082,9 +2077,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2092,9 +2088,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2102,9 +2099,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2112,9 +2110,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2122,9 +2121,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2132,9 +2132,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2142,9 +2143,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2152,9 +2154,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2162,9 +2165,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2172,9 +2176,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2182,9 +2187,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2192,9 +2198,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2202,9 +2209,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2212,9 +2220,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2222,9 +2231,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2232,9 +2242,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2242,9 +2253,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2252,9 +2264,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2262,9 +2275,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2272,9 +2286,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2282,9 +2297,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2292,9 +2308,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2302,9 +2319,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2313,9 +2331,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -69,10 +69,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -120,10 +119,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -171,10 +169,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -222,10 +219,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -263,10 +259,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -326,10 +321,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -2139,9 +2133,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2149,9 +2144,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2159,9 +2155,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2169,9 +2166,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2179,9 +2177,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2189,9 +2188,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2199,9 +2199,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2209,9 +2210,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2219,9 +2221,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2229,9 +2232,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2239,9 +2243,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2249,9 +2254,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2259,9 +2265,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2269,9 +2276,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2279,9 +2287,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2289,9 +2298,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2299,9 +2309,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2309,9 +2320,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2319,9 +2331,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2329,9 +2342,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2339,9 +2353,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2349,9 +2364,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2359,9 +2375,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2369,9 +2386,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {23})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -2379,9 +2397,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2390,9 +2409,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1893,9 +1893,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T1, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1903,9 +1904,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {1})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T2, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1913,9 +1915,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {2})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T3, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1923,9 +1926,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {3})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T4, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1933,9 +1937,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {4})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T5, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1943,9 +1948,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {5})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T6, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1953,9 +1959,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {6})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T7, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1963,9 +1970,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {7})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T8, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1973,9 +1981,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {8})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T9, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1983,9 +1992,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {9})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T10, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1993,9 +2003,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {10})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T11, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2003,9 +2014,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {11})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T12, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2013,9 +2025,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {12})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T13, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2023,9 +2036,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {13})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T14, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2033,9 +2047,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {14})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T15, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2043,9 +2058,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {15})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T16, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2053,9 +2069,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {16})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T17, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2063,9 +2080,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {17})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T18, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2073,9 +2091,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {18})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T19, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2083,9 +2102,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {19})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T20, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2093,9 +2113,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {20})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T21, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2103,9 +2124,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {21})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T22, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2113,9 +2135,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {22})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T23, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2123,9 +2146,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {23})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T24, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -2133,9 +2157,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T25, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {24})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T25, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -2143,9 +2168,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, Nothing)
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2154,9 +2180,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpression.vb
@@ -47,9 +47,10 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T))) As SelectedSelectSqlExpression(Of T)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -58,9 +59,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T, TProperty))) As SelectedSelectSqlExpression(Of T)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -68,9 +70,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -81,9 +84,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2.vb
@@ -86,18 +86,20 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -106,9 +108,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -117,9 +120,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -128,9 +132,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -139,18 +144,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2)))) As SelectedSelectSqlExpression(Of T1, T2)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -159,9 +166,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2), TProperty))) As SelectedSelectSqlExpression(Of T1, T2)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -169,9 +177,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -182,9 +191,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3.vb
@@ -105,27 +105,30 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -134,9 +137,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -145,9 +149,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -156,9 +161,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -167,9 +173,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -178,9 +185,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -189,9 +197,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -200,9 +209,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -211,9 +221,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -222,18 +233,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3)))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -242,9 +255,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -252,9 +266,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -265,9 +280,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4.vb
@@ -124,36 +124,40 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -162,9 +166,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -173,9 +178,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -184,9 +190,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -195,9 +202,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -206,9 +214,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -217,9 +226,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -228,9 +238,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -239,9 +250,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -250,9 +262,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -261,9 +274,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -272,9 +286,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -283,9 +298,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -294,9 +310,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -305,9 +322,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -316,9 +334,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -327,18 +346,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -347,9 +368,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -357,9 +379,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -370,9 +393,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -143,45 +143,50 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -190,9 +195,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -201,9 +207,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -212,9 +219,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -223,9 +231,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -234,9 +243,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -245,9 +255,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -256,9 +267,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -267,9 +279,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -278,9 +291,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -289,9 +303,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -300,9 +315,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -311,9 +327,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -322,9 +339,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -333,9 +351,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -344,9 +363,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -355,9 +375,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -366,9 +387,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -377,9 +399,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -388,9 +411,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -399,9 +423,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -410,9 +435,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -421,9 +447,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -432,9 +459,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -443,9 +471,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -454,18 +483,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -474,9 +505,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -484,9 +516,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -497,9 +530,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -162,54 +162,60 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -218,9 +224,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -229,9 +236,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -240,9 +248,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -251,9 +260,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -262,9 +272,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -273,9 +284,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -284,9 +296,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -295,9 +308,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -306,9 +320,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -317,9 +332,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -328,9 +344,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -339,9 +356,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -350,9 +368,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -361,9 +380,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -372,9 +392,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -383,9 +404,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -394,9 +416,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -405,9 +428,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -416,9 +440,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -427,9 +452,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -438,9 +464,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -449,9 +476,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -460,9 +488,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -471,9 +500,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -482,9 +512,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -493,9 +524,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -504,9 +536,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -515,9 +548,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -526,9 +560,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -537,9 +572,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -548,9 +584,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -559,9 +596,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -570,9 +608,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -581,9 +620,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -592,9 +632,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -603,18 +644,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -623,9 +666,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -633,9 +677,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -646,9 +691,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -181,63 +181,70 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -246,9 +253,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -257,9 +265,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -268,9 +277,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -279,9 +289,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -290,9 +301,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -301,9 +313,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -312,9 +325,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -323,9 +337,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -334,9 +349,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -345,9 +361,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -356,9 +373,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -367,9 +385,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -378,9 +397,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -389,9 +409,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -400,9 +421,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -411,9 +433,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -422,9 +445,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -433,9 +457,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -444,9 +469,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -455,9 +481,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -466,9 +493,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -477,9 +505,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -488,9 +517,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -499,9 +529,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -510,9 +541,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -521,9 +553,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -532,9 +565,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -543,9 +577,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -554,9 +589,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -565,9 +601,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -576,9 +613,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -587,9 +625,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -598,9 +637,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -609,9 +649,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -620,9 +661,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -631,9 +673,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -642,9 +685,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -653,9 +697,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -664,9 +709,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -675,9 +721,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -686,9 +733,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -697,9 +745,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -708,9 +757,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -719,9 +769,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -730,9 +781,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -741,9 +793,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -752,9 +805,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -763,9 +817,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -774,18 +829,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -794,9 +851,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -804,9 +862,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -817,9 +876,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -200,72 +200,80 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -274,9 +282,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -285,9 +294,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -296,9 +306,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -307,9 +318,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -318,9 +330,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -329,9 +342,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -340,9 +354,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -351,9 +366,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -362,9 +378,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -373,9 +390,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -384,9 +402,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -395,9 +414,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -406,9 +426,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -417,9 +438,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -428,9 +450,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -439,9 +462,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -450,9 +474,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -461,9 +486,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -472,9 +498,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -483,9 +510,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -494,9 +522,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -505,9 +534,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -516,9 +546,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -527,9 +558,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -538,9 +570,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -549,9 +582,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -560,9 +594,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -571,9 +606,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -582,9 +618,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -593,9 +630,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -604,9 +642,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -615,9 +654,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -626,9 +666,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -637,9 +678,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -648,9 +690,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -659,9 +702,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -670,9 +714,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -681,9 +726,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -692,9 +738,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -703,9 +750,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -714,9 +762,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -725,9 +774,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -736,9 +786,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -747,9 +798,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -758,9 +810,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -769,9 +822,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -780,9 +834,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -791,9 +846,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -802,9 +858,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -813,9 +870,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -824,9 +882,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -835,9 +894,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -846,9 +906,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -857,9 +918,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -868,9 +930,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -879,9 +942,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -890,9 +954,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -901,9 +966,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -912,9 +978,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -923,9 +990,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -934,9 +1002,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -945,9 +1014,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -956,9 +1026,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -967,18 +1038,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -987,9 +1060,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -997,9 +1071,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -1010,9 +1085,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -219,81 +219,90 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -302,9 +311,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -313,9 +323,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -324,9 +335,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -335,9 +347,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -346,9 +359,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -357,9 +371,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -368,9 +383,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -379,9 +395,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -390,9 +407,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -401,9 +419,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -412,9 +431,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -423,9 +443,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -434,9 +455,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -445,9 +467,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -456,9 +479,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -467,9 +491,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -478,9 +503,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -489,9 +515,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -500,9 +527,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -511,9 +539,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -522,9 +551,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -533,9 +563,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -544,9 +575,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -555,9 +587,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -566,9 +599,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -577,9 +611,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -588,9 +623,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -599,9 +635,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -610,9 +647,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -621,9 +659,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -632,9 +671,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -643,9 +683,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -654,9 +695,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -665,9 +707,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -676,9 +719,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -687,9 +731,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -698,9 +743,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -709,9 +755,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -720,9 +767,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -731,9 +779,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -742,9 +791,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -753,9 +803,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -764,9 +815,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -775,9 +827,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -786,9 +839,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -797,9 +851,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -808,9 +863,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -819,9 +875,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -830,9 +887,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -841,9 +899,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -852,9 +911,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -863,9 +923,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -874,9 +935,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -885,9 +947,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -896,9 +959,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -907,9 +971,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -918,9 +983,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -929,9 +995,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -940,9 +1007,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -951,9 +1019,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -962,9 +1031,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -973,9 +1043,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -984,9 +1055,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -995,9 +1067,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1006,9 +1079,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1017,9 +1091,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1028,9 +1103,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1039,9 +1115,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1050,9 +1127,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1061,9 +1139,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1072,9 +1151,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1083,9 +1163,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1094,9 +1175,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1105,9 +1187,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1116,9 +1199,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1127,9 +1211,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1138,9 +1223,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1149,9 +1235,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1160,9 +1247,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1171,9 +1259,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1182,18 +1271,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1202,9 +1293,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1212,9 +1304,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -1225,9 +1318,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -238,90 +238,100 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -330,9 +340,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -341,9 +352,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -352,9 +364,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -363,9 +376,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -374,9 +388,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -385,9 +400,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -396,9 +412,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -407,9 +424,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -418,9 +436,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -429,9 +448,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -440,9 +460,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -451,9 +472,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -462,9 +484,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -473,9 +496,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -484,9 +508,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -495,9 +520,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -506,9 +532,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -517,9 +544,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -528,9 +556,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -539,9 +568,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -550,9 +580,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -561,9 +592,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -572,9 +604,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -583,9 +616,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -594,9 +628,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -605,9 +640,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -616,9 +652,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -627,9 +664,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -638,9 +676,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -649,9 +688,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -660,9 +700,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -671,9 +712,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -682,9 +724,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -693,9 +736,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -704,9 +748,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -715,9 +760,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -726,9 +772,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -737,9 +784,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -748,9 +796,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -759,9 +808,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -770,9 +820,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -781,9 +832,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -792,9 +844,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -803,9 +856,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -814,9 +868,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -825,9 +880,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -836,9 +892,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -847,9 +904,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -858,9 +916,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -869,9 +928,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -880,9 +940,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -891,9 +952,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -902,9 +964,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -913,9 +976,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -924,9 +988,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -935,9 +1000,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -946,9 +1012,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -957,9 +1024,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -968,9 +1036,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -979,9 +1048,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -990,9 +1060,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1001,9 +1072,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1012,9 +1084,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1023,9 +1096,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1034,9 +1108,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1045,9 +1120,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1056,9 +1132,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1067,9 +1144,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1078,9 +1156,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1089,9 +1168,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1100,9 +1180,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1111,9 +1192,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1122,9 +1204,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1133,9 +1216,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1144,9 +1228,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1155,9 +1240,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1166,9 +1252,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1177,9 +1264,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1188,9 +1276,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1199,9 +1288,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1210,9 +1300,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1221,9 +1312,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1232,9 +1324,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1243,9 +1336,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1254,9 +1348,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1265,9 +1360,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1276,9 +1372,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1287,9 +1384,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1298,9 +1396,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1309,9 +1408,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1320,9 +1420,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1331,9 +1432,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1342,9 +1444,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1353,9 +1456,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1364,9 +1468,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1375,9 +1480,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1386,9 +1492,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1397,9 +1504,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1408,9 +1516,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1419,18 +1528,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1439,9 +1550,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1449,9 +1561,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -1462,9 +1575,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -257,99 +257,110 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -358,9 +369,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -369,9 +381,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -380,9 +393,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -391,9 +405,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -402,9 +417,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -413,9 +429,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -424,9 +441,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -435,9 +453,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -446,9 +465,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -457,9 +477,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -468,9 +489,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -479,9 +501,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -490,9 +513,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -501,9 +525,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -512,9 +537,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -523,9 +549,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -534,9 +561,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -545,9 +573,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -556,9 +585,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -567,9 +597,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -578,9 +609,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -589,9 +621,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -600,9 +633,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -611,9 +645,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -622,9 +657,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -633,9 +669,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -644,9 +681,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -655,9 +693,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -666,9 +705,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -677,9 +717,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -688,9 +729,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -699,9 +741,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -710,9 +753,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -721,9 +765,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -732,9 +777,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -743,9 +789,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -754,9 +801,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -765,9 +813,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -776,9 +825,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -787,9 +837,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -798,9 +849,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -809,9 +861,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -820,9 +873,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -831,9 +885,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -842,9 +897,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -853,9 +909,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -864,9 +921,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -875,9 +933,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -886,9 +945,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -897,9 +957,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -908,9 +969,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -919,9 +981,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -930,9 +993,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -941,9 +1005,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -952,9 +1017,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -963,9 +1029,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -974,9 +1041,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -985,9 +1053,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -996,9 +1065,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1007,9 +1077,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1018,9 +1089,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1029,9 +1101,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1040,9 +1113,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1051,9 +1125,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1062,9 +1137,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1073,9 +1149,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1084,9 +1161,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1095,9 +1173,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1106,9 +1185,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1117,9 +1197,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1128,9 +1209,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1139,9 +1221,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1150,9 +1233,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1161,9 +1245,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1172,9 +1257,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1183,9 +1269,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1194,9 +1281,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1205,9 +1293,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1216,9 +1305,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1227,9 +1317,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1238,9 +1329,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1249,9 +1341,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1260,9 +1353,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1271,9 +1365,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1282,9 +1377,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1293,9 +1389,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1304,9 +1401,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1315,9 +1413,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1326,9 +1425,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1337,9 +1437,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1348,9 +1449,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1359,9 +1461,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1370,9 +1473,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1381,9 +1485,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1392,9 +1497,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1403,9 +1509,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1414,9 +1521,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1425,9 +1533,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1436,9 +1545,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1447,9 +1557,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1458,9 +1569,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1469,9 +1581,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1480,9 +1593,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1491,9 +1605,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1502,9 +1617,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1513,9 +1629,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1524,9 +1641,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1535,9 +1653,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1546,9 +1665,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1557,9 +1677,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1568,9 +1689,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1579,9 +1701,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1590,9 +1713,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1601,9 +1725,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1612,9 +1737,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1623,9 +1749,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1634,9 +1761,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1645,9 +1773,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1656,9 +1785,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1667,9 +1797,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1678,18 +1809,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1698,9 +1831,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1708,9 +1842,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -1721,9 +1856,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -276,108 +276,120 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -386,9 +398,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -397,9 +410,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -408,9 +422,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -419,9 +434,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -430,9 +446,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -441,9 +458,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -452,9 +470,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -463,9 +482,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -474,9 +494,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -485,9 +506,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -496,9 +518,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -507,9 +530,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -518,9 +542,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -529,9 +554,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -540,9 +566,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -551,9 +578,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -562,9 +590,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -573,9 +602,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -584,9 +614,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -595,9 +626,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -606,9 +638,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -617,9 +650,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -628,9 +662,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -639,9 +674,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -650,9 +686,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -661,9 +698,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -672,9 +710,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -683,9 +722,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -694,9 +734,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -705,9 +746,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -716,9 +758,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -727,9 +770,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -738,9 +782,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -749,9 +794,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -760,9 +806,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -771,9 +818,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -782,9 +830,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -793,9 +842,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -804,9 +854,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -815,9 +866,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -826,9 +878,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -837,9 +890,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -848,9 +902,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -859,9 +914,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -870,9 +926,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -881,9 +938,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -892,9 +950,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -903,9 +962,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -914,9 +974,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -925,9 +986,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -936,9 +998,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -947,9 +1010,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -958,9 +1022,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -969,9 +1034,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -980,9 +1046,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -991,9 +1058,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1002,9 +1070,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1013,9 +1082,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1024,9 +1094,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1035,9 +1106,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1046,9 +1118,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1057,9 +1130,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1068,9 +1142,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1079,9 +1154,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1090,9 +1166,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1101,9 +1178,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1112,9 +1190,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1123,9 +1202,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1134,9 +1214,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1145,9 +1226,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1156,9 +1238,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1167,9 +1250,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1178,9 +1262,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1189,9 +1274,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1200,9 +1286,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1211,9 +1298,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1222,9 +1310,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1233,9 +1322,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1244,9 +1334,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1255,9 +1346,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1266,9 +1358,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1277,9 +1370,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1288,9 +1382,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1299,9 +1394,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1310,9 +1406,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1321,9 +1418,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1332,9 +1430,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1343,9 +1442,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1354,9 +1454,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1365,9 +1466,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1376,9 +1478,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1387,9 +1490,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1398,9 +1502,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1409,9 +1514,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1420,9 +1526,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1431,9 +1538,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1442,9 +1550,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1453,9 +1562,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1464,9 +1574,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1475,9 +1586,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1486,9 +1598,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1497,9 +1610,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1508,9 +1622,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1519,9 +1634,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1530,9 +1646,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1541,9 +1658,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1552,9 +1670,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1563,9 +1682,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1574,9 +1694,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1585,9 +1706,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1596,9 +1718,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1607,9 +1730,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1618,9 +1742,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1629,9 +1754,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1640,9 +1766,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1651,9 +1778,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1662,9 +1790,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1673,9 +1802,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1684,9 +1814,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1695,9 +1826,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1706,9 +1838,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1717,9 +1850,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1728,9 +1862,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1739,9 +1874,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1750,9 +1886,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1761,9 +1898,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1772,9 +1910,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1783,9 +1922,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1794,9 +1934,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1805,9 +1946,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1816,9 +1958,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1827,9 +1970,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1838,9 +1982,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1849,9 +1994,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1860,9 +2006,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1871,9 +2018,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1882,9 +2030,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1893,9 +2042,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1904,9 +2054,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1915,9 +2066,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1926,9 +2078,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1937,9 +2090,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1948,9 +2102,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1959,18 +2114,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1979,9 +2136,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -1989,9 +2147,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -2002,9 +2161,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -295,117 +295,130 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, {12})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -414,9 +427,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -425,9 +439,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -436,9 +451,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -447,9 +463,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -458,9 +475,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -469,9 +487,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -480,9 +499,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -491,9 +511,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -502,9 +523,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -513,9 +535,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -524,9 +547,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -535,9 +559,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -546,9 +571,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -557,9 +583,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -568,9 +595,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -579,9 +607,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -590,9 +619,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -601,9 +631,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -612,9 +643,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -623,9 +655,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -634,9 +667,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -645,9 +679,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -656,9 +691,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -667,9 +703,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -678,9 +715,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -689,9 +727,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -700,9 +739,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -711,9 +751,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -722,9 +763,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -733,9 +775,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -744,9 +787,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -755,9 +799,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -766,9 +811,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -777,9 +823,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -788,9 +835,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -799,9 +847,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -810,9 +859,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -821,9 +871,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -832,9 +883,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -843,9 +895,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -854,9 +907,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -865,9 +919,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -876,9 +931,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -887,9 +943,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -898,9 +955,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -909,9 +967,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -920,9 +979,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -931,9 +991,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -942,9 +1003,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -953,9 +1015,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -964,9 +1027,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -975,9 +1039,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -986,9 +1051,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -997,9 +1063,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1008,9 +1075,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1019,9 +1087,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1030,9 +1099,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1041,9 +1111,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1052,9 +1123,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1063,9 +1135,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1074,9 +1147,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1085,9 +1159,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1096,9 +1171,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1107,9 +1183,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1118,9 +1195,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1129,9 +1207,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1140,9 +1219,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1151,9 +1231,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1162,9 +1243,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1173,9 +1255,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1184,9 +1267,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1195,9 +1279,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1206,9 +1291,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1217,9 +1303,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1228,9 +1315,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1239,9 +1327,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1250,9 +1339,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1261,9 +1351,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1272,9 +1363,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1283,9 +1375,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1294,9 +1387,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1305,9 +1399,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1316,9 +1411,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1327,9 +1423,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1338,9 +1435,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1349,9 +1447,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1360,9 +1459,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1371,9 +1471,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1382,9 +1483,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1393,9 +1495,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1404,9 +1507,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1415,9 +1519,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1426,9 +1531,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1437,9 +1543,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1448,9 +1555,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1459,9 +1567,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1470,9 +1579,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1481,9 +1591,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1492,9 +1603,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1503,9 +1615,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1514,9 +1627,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1525,9 +1639,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1536,9 +1651,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1547,9 +1663,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1558,9 +1675,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1569,9 +1687,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1580,9 +1699,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1591,9 +1711,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1602,9 +1723,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1613,9 +1735,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1624,9 +1747,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1635,9 +1759,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1646,9 +1771,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1657,9 +1783,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1668,9 +1795,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1679,9 +1807,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1690,9 +1819,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1701,9 +1831,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1712,9 +1843,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1723,9 +1855,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1734,9 +1867,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1745,9 +1879,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1756,9 +1891,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1767,9 +1903,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1778,9 +1915,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1789,9 +1927,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1800,9 +1939,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1811,9 +1951,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1822,9 +1963,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1833,9 +1975,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1844,9 +1987,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1855,9 +1999,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1866,9 +2011,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1877,9 +2023,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1888,9 +2035,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1899,9 +2047,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1910,9 +2059,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1921,9 +2071,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1932,9 +2083,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1943,9 +2095,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1954,9 +2107,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1965,9 +2119,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1976,9 +2131,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1987,9 +2143,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1998,9 +2155,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2009,9 +2167,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2020,9 +2179,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2031,9 +2191,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2042,9 +2203,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2053,9 +2215,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2064,9 +2227,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2075,9 +2239,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2086,9 +2251,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2097,9 +2263,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2108,9 +2275,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2119,9 +2287,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2130,9 +2299,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2141,9 +2311,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2152,9 +2323,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2163,9 +2335,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2174,9 +2347,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2185,9 +2359,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2196,9 +2371,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2207,9 +2383,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2218,9 +2395,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2229,9 +2407,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2240,9 +2419,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2251,9 +2431,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2262,18 +2443,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2282,9 +2465,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2292,9 +2476,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -2305,9 +2490,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -314,126 +314,140 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {12})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {12}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, {13})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -442,9 +456,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -453,9 +468,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -464,9 +480,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -475,9 +492,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -486,9 +504,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -497,9 +516,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -508,9 +528,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -519,9 +540,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -530,9 +552,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -541,9 +564,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -552,9 +576,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -563,9 +588,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -574,9 +600,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -585,9 +612,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -596,9 +624,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -607,9 +636,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -618,9 +648,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -629,9 +660,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -640,9 +672,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -651,9 +684,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -662,9 +696,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -673,9 +708,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -684,9 +720,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -695,9 +732,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -706,9 +744,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -717,9 +756,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -728,9 +768,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -739,9 +780,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -750,9 +792,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -761,9 +804,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -772,9 +816,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -783,9 +828,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -794,9 +840,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -805,9 +852,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -816,9 +864,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -827,9 +876,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -838,9 +888,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -849,9 +900,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -860,9 +912,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -871,9 +924,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -882,9 +936,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -893,9 +948,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -904,9 +960,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -915,9 +972,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -926,9 +984,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -937,9 +996,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -948,9 +1008,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -959,9 +1020,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -970,9 +1032,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -981,9 +1044,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -992,9 +1056,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1003,9 +1068,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1014,9 +1080,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1025,9 +1092,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1036,9 +1104,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1047,9 +1116,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1058,9 +1128,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1069,9 +1140,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1080,9 +1152,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1091,9 +1164,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1102,9 +1176,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1113,9 +1188,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1124,9 +1200,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1135,9 +1212,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1146,9 +1224,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1157,9 +1236,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1168,9 +1248,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1179,9 +1260,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1190,9 +1272,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1201,9 +1284,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1212,9 +1296,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1223,9 +1308,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1234,9 +1320,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1245,9 +1332,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1256,9 +1344,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1267,9 +1356,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1278,9 +1368,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1289,9 +1380,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1300,9 +1392,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1311,9 +1404,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1322,9 +1416,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1333,9 +1428,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1344,9 +1440,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1355,9 +1452,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1366,9 +1464,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1377,9 +1476,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1388,9 +1488,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1399,9 +1500,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1410,9 +1512,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1421,9 +1524,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1432,9 +1536,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1443,9 +1548,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1454,9 +1560,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1465,9 +1572,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1476,9 +1584,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1487,9 +1596,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1498,9 +1608,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1509,9 +1620,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1520,9 +1632,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1531,9 +1644,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1542,9 +1656,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1553,9 +1668,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1564,9 +1680,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1575,9 +1692,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1586,9 +1704,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1597,9 +1716,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1608,9 +1728,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1619,9 +1740,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1630,9 +1752,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1641,9 +1764,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1652,9 +1776,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1663,9 +1788,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1674,9 +1800,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1685,9 +1812,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1696,9 +1824,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1707,9 +1836,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1718,9 +1848,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1729,9 +1860,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1740,9 +1872,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1751,9 +1884,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1762,9 +1896,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1773,9 +1908,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1784,9 +1920,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1795,9 +1932,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1806,9 +1944,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1817,9 +1956,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1828,9 +1968,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1839,9 +1980,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1850,9 +1992,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1861,9 +2004,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1872,9 +2016,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1883,9 +2028,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1894,9 +2040,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1905,9 +2052,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1916,9 +2064,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1927,9 +2076,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1938,9 +2088,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1949,9 +2100,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1960,9 +2112,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1971,9 +2124,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1982,9 +2136,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1993,9 +2148,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2004,9 +2160,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2015,9 +2172,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2026,9 +2184,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2037,9 +2196,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2048,9 +2208,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2059,9 +2220,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2070,9 +2232,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2081,9 +2244,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2092,9 +2256,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2103,9 +2268,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2114,9 +2280,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2125,9 +2292,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2136,9 +2304,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2147,9 +2316,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2158,9 +2328,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2169,9 +2340,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2180,9 +2352,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2191,9 +2364,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2202,9 +2376,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2213,9 +2388,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2224,9 +2400,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2235,9 +2412,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2246,9 +2424,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2257,9 +2436,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2268,9 +2448,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2279,9 +2460,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2290,9 +2472,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2301,9 +2484,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2312,9 +2496,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2323,9 +2508,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2334,9 +2520,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2345,9 +2532,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2356,9 +2544,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2367,9 +2556,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2378,9 +2568,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2389,9 +2580,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2400,9 +2592,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2411,9 +2604,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2422,9 +2616,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2433,9 +2628,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2444,9 +2640,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2455,9 +2652,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2466,9 +2664,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2477,9 +2676,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2488,9 +2688,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2499,9 +2700,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2510,9 +2712,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2521,9 +2724,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2532,9 +2736,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2543,9 +2748,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2554,9 +2760,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2565,9 +2772,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2576,9 +2784,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2587,18 +2796,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2607,9 +2818,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2617,9 +2829,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -2630,9 +2843,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -333,135 +333,150 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {12})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {12}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {13})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {13}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, {14})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -470,9 +485,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -481,9 +497,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -492,9 +509,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -503,9 +521,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -514,9 +533,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -525,9 +545,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -536,9 +557,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -547,9 +569,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -558,9 +581,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -569,9 +593,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -580,9 +605,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -591,9 +617,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -602,9 +629,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -613,9 +641,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -624,9 +653,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -635,9 +665,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -646,9 +677,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -657,9 +689,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -668,9 +701,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -679,9 +713,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -690,9 +725,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -701,9 +737,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -712,9 +749,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -723,9 +761,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -734,9 +773,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -745,9 +785,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -756,9 +797,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -767,9 +809,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -778,9 +821,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -789,9 +833,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -800,9 +845,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -811,9 +857,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -822,9 +869,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -833,9 +881,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -844,9 +893,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -855,9 +905,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -866,9 +917,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -877,9 +929,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -888,9 +941,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -899,9 +953,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -910,9 +965,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -921,9 +977,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -932,9 +989,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -943,9 +1001,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -954,9 +1013,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -965,9 +1025,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -976,9 +1037,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -987,9 +1049,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -998,9 +1061,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1009,9 +1073,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1020,9 +1085,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1031,9 +1097,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1042,9 +1109,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1053,9 +1121,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1064,9 +1133,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1075,9 +1145,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1086,9 +1157,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1097,9 +1169,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1108,9 +1181,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1119,9 +1193,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1130,9 +1205,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1141,9 +1217,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1152,9 +1229,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1163,9 +1241,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1174,9 +1253,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1185,9 +1265,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1196,9 +1277,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1207,9 +1289,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1218,9 +1301,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1229,9 +1313,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1240,9 +1325,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1251,9 +1337,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1262,9 +1349,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1273,9 +1361,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1284,9 +1373,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1295,9 +1385,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1306,9 +1397,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1317,9 +1409,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1328,9 +1421,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1339,9 +1433,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1350,9 +1445,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1361,9 +1457,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1372,9 +1469,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1383,9 +1481,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1394,9 +1493,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1405,9 +1505,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1416,9 +1517,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1427,9 +1529,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1438,9 +1541,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1449,9 +1553,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1460,9 +1565,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1471,9 +1577,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1482,9 +1589,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1493,9 +1601,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1504,9 +1613,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1515,9 +1625,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1526,9 +1637,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1537,9 +1649,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1548,9 +1661,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1559,9 +1673,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1570,9 +1685,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1581,9 +1697,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1592,9 +1709,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1603,9 +1721,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1614,9 +1733,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1625,9 +1745,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1636,9 +1757,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1647,9 +1769,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1658,9 +1781,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1669,9 +1793,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1680,9 +1805,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1691,9 +1817,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1702,9 +1829,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1713,9 +1841,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1724,9 +1853,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1735,9 +1865,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1746,9 +1877,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1757,9 +1889,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1768,9 +1901,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1779,9 +1913,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1790,9 +1925,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1801,9 +1937,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1812,9 +1949,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1823,9 +1961,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1834,9 +1973,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1845,9 +1985,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1856,9 +1997,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1867,9 +2009,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1878,9 +2021,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1889,9 +2033,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1900,9 +2045,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1911,9 +2057,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1922,9 +2069,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1933,9 +2081,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1944,9 +2093,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1955,9 +2105,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1966,9 +2117,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1977,9 +2129,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1988,9 +2141,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1999,9 +2153,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2010,9 +2165,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2021,9 +2177,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2032,9 +2189,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2043,9 +2201,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2054,9 +2213,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2065,9 +2225,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2076,9 +2237,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2087,9 +2249,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2098,9 +2261,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2109,9 +2273,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2120,9 +2285,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2131,9 +2297,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2142,9 +2309,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2153,9 +2321,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2164,9 +2333,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2175,9 +2345,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2186,9 +2357,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2197,9 +2369,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2208,9 +2381,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2219,9 +2393,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2230,9 +2405,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2241,9 +2417,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2252,9 +2429,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2263,9 +2441,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2274,9 +2453,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2285,9 +2465,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2296,9 +2477,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2307,9 +2489,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2318,9 +2501,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2329,9 +2513,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2340,9 +2525,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2351,9 +2537,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2362,9 +2549,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2373,9 +2561,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2384,9 +2573,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2395,9 +2585,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2406,9 +2597,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2417,9 +2609,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2428,9 +2621,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2439,9 +2633,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2450,9 +2645,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2461,9 +2657,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2472,9 +2669,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2483,9 +2681,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2494,9 +2693,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2505,9 +2705,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2516,9 +2717,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2527,9 +2729,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2538,9 +2741,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2549,9 +2753,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2560,9 +2765,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2571,9 +2777,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2582,9 +2789,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2593,9 +2801,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2604,9 +2813,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2615,9 +2825,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2626,9 +2837,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2637,9 +2849,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2648,9 +2861,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2659,9 +2873,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2670,9 +2885,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2681,9 +2897,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2692,9 +2909,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2703,9 +2921,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2714,9 +2933,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2725,9 +2945,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2736,9 +2957,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2747,9 +2969,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2758,9 +2981,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2769,9 +2993,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2780,9 +3005,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2791,9 +3017,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2802,9 +3029,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2813,9 +3041,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2824,9 +3053,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2835,9 +3065,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2846,9 +3077,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2857,9 +3089,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2868,9 +3101,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2879,9 +3113,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2890,9 +3125,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2901,9 +3137,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2912,9 +3149,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2923,9 +3161,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2934,18 +3173,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2954,9 +3195,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -2964,9 +3206,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -2977,9 +3220,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -352,144 +352,160 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {12})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {12}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {13})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {13}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {14})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {14}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, {15})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -498,9 +514,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -509,9 +526,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -520,9 +538,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -531,9 +550,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -542,9 +562,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -553,9 +574,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -564,9 +586,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -575,9 +598,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -586,9 +610,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -597,9 +622,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -608,9 +634,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -619,9 +646,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -630,9 +658,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -641,9 +670,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -652,9 +682,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -663,9 +694,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -674,9 +706,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -685,9 +718,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -696,9 +730,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -707,9 +742,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -718,9 +754,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -729,9 +766,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -740,9 +778,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -751,9 +790,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -762,9 +802,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -773,9 +814,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -784,9 +826,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -795,9 +838,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -806,9 +850,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -817,9 +862,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -828,9 +874,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -839,9 +886,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -850,9 +898,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -861,9 +910,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -872,9 +922,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -883,9 +934,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -894,9 +946,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -905,9 +958,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -916,9 +970,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -927,9 +982,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -938,9 +994,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -949,9 +1006,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -960,9 +1018,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -971,9 +1030,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -982,9 +1042,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -993,9 +1054,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1004,9 +1066,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1015,9 +1078,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1026,9 +1090,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1037,9 +1102,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1048,9 +1114,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1059,9 +1126,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1070,9 +1138,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1081,9 +1150,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1092,9 +1162,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1103,9 +1174,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1114,9 +1186,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1125,9 +1198,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1136,9 +1210,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1147,9 +1222,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1158,9 +1234,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1169,9 +1246,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1180,9 +1258,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1191,9 +1270,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1202,9 +1282,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1213,9 +1294,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1224,9 +1306,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1235,9 +1318,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1246,9 +1330,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1257,9 +1342,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1268,9 +1354,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1279,9 +1366,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1290,9 +1378,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1301,9 +1390,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1312,9 +1402,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1323,9 +1414,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1334,9 +1426,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1345,9 +1438,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1356,9 +1450,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1367,9 +1462,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1378,9 +1474,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1389,9 +1486,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1400,9 +1498,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1411,9 +1510,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1422,9 +1522,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1433,9 +1534,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1444,9 +1546,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1455,9 +1558,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1466,9 +1570,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1477,9 +1582,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1488,9 +1594,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1499,9 +1606,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1510,9 +1618,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1521,9 +1630,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1532,9 +1642,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1543,9 +1654,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1554,9 +1666,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1565,9 +1678,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1576,9 +1690,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1587,9 +1702,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1598,9 +1714,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1609,9 +1726,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1620,9 +1738,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1631,9 +1750,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1642,9 +1762,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1653,9 +1774,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1664,9 +1786,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1675,9 +1798,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1686,9 +1810,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1697,9 +1822,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1708,9 +1834,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1719,9 +1846,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1730,9 +1858,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1741,9 +1870,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1752,9 +1882,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1763,9 +1894,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1774,9 +1906,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1785,9 +1918,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1796,9 +1930,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1807,9 +1942,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1818,9 +1954,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1829,9 +1966,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1840,9 +1978,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1851,9 +1990,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1862,9 +2002,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1873,9 +2014,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1884,9 +2026,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1895,9 +2038,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1906,9 +2050,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1917,9 +2062,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1928,9 +2074,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1939,9 +2086,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1950,9 +2098,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1961,9 +2110,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1972,9 +2122,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1983,9 +2134,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1994,9 +2146,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2005,9 +2158,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2016,9 +2170,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2027,9 +2182,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2038,9 +2194,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2049,9 +2206,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2060,9 +2218,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2071,9 +2230,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2082,9 +2242,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2093,9 +2254,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2104,9 +2266,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2115,9 +2278,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2126,9 +2290,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2137,9 +2302,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2148,9 +2314,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2159,9 +2326,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2170,9 +2338,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2181,9 +2350,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2192,9 +2362,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2203,9 +2374,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2214,9 +2386,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2225,9 +2398,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2236,9 +2410,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2247,9 +2422,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2258,9 +2434,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2269,9 +2446,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2280,9 +2458,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2291,9 +2470,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2302,9 +2482,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2313,9 +2494,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2324,9 +2506,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2335,9 +2518,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2346,9 +2530,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2357,9 +2542,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2368,9 +2554,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2379,9 +2566,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2390,9 +2578,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2401,9 +2590,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2412,9 +2602,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2423,9 +2614,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2434,9 +2626,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2445,9 +2638,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2456,9 +2650,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2467,9 +2662,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2478,9 +2674,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2489,9 +2686,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2500,9 +2698,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2511,9 +2710,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2522,9 +2722,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2533,9 +2734,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2544,9 +2746,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2555,9 +2758,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2566,9 +2770,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2577,9 +2782,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2588,9 +2794,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2599,9 +2806,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2610,9 +2818,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2621,9 +2830,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2632,9 +2842,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2643,9 +2854,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2654,9 +2866,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2665,9 +2878,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2676,9 +2890,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2687,9 +2902,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2698,9 +2914,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2709,9 +2926,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2720,9 +2938,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2731,9 +2950,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2742,9 +2962,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2753,9 +2974,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2764,9 +2986,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2775,9 +2998,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2786,9 +3010,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2797,9 +3022,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2808,9 +3034,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2819,9 +3046,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2830,9 +3058,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2841,9 +3070,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2852,9 +3082,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2863,9 +3094,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2874,9 +3106,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2885,9 +3118,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2896,9 +3130,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2907,9 +3142,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2918,9 +3154,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2929,9 +3166,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2940,9 +3178,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2951,9 +3190,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2962,9 +3202,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2973,9 +3214,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2984,9 +3226,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2995,9 +3238,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3006,9 +3250,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3017,9 +3262,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3028,9 +3274,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3039,9 +3286,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3050,9 +3298,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3061,9 +3310,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3072,9 +3322,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3083,9 +3334,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3094,9 +3346,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3105,9 +3358,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3116,9 +3370,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3127,9 +3382,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3138,9 +3394,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3149,9 +3406,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3160,9 +3418,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3171,9 +3430,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3182,9 +3442,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3193,9 +3454,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3204,9 +3466,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3215,9 +3478,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3226,9 +3490,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3237,9 +3502,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3248,9 +3514,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3259,9 +3526,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3270,9 +3538,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3281,9 +3550,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3292,9 +3562,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3303,18 +3574,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -3323,9 +3596,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -3333,9 +3607,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -3346,9 +3621,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -371,153 +371,170 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {12})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {12}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {13})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {13}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {14})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {14}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {15})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {15}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, {16})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -526,9 +543,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -537,9 +555,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -548,9 +567,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -559,9 +579,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -570,9 +591,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -581,9 +603,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -592,9 +615,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -603,9 +627,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -614,9 +639,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -625,9 +651,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -636,9 +663,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -647,9 +675,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -658,9 +687,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -669,9 +699,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -680,9 +711,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -691,9 +723,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -702,9 +735,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -713,9 +747,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -724,9 +759,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -735,9 +771,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -746,9 +783,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -757,9 +795,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -768,9 +807,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -779,9 +819,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -790,9 +831,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -801,9 +843,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -812,9 +855,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -823,9 +867,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -834,9 +879,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -845,9 +891,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -856,9 +903,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -867,9 +915,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -878,9 +927,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -889,9 +939,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -900,9 +951,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -911,9 +963,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -922,9 +975,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -933,9 +987,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -944,9 +999,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -955,9 +1011,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -966,9 +1023,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -977,9 +1035,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -988,9 +1047,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -999,9 +1059,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1010,9 +1071,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1021,9 +1083,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1032,9 +1095,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1043,9 +1107,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1054,9 +1119,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1065,9 +1131,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1076,9 +1143,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1087,9 +1155,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1098,9 +1167,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1109,9 +1179,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1120,9 +1191,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1131,9 +1203,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1142,9 +1215,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1153,9 +1227,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1164,9 +1239,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1175,9 +1251,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1186,9 +1263,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1197,9 +1275,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1208,9 +1287,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1219,9 +1299,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1230,9 +1311,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1241,9 +1323,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1252,9 +1335,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1263,9 +1347,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1274,9 +1359,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1285,9 +1371,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1296,9 +1383,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1307,9 +1395,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1318,9 +1407,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1329,9 +1419,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1340,9 +1431,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1351,9 +1443,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1362,9 +1455,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1373,9 +1467,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1384,9 +1479,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1395,9 +1491,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1406,9 +1503,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1417,9 +1515,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1428,9 +1527,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1439,9 +1539,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1450,9 +1551,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1461,9 +1563,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1472,9 +1575,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1483,9 +1587,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1494,9 +1599,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1505,9 +1611,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1516,9 +1623,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1527,9 +1635,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1538,9 +1647,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1549,9 +1659,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1560,9 +1671,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1571,9 +1683,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1582,9 +1695,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1593,9 +1707,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1604,9 +1719,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1615,9 +1731,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1626,9 +1743,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1637,9 +1755,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1648,9 +1767,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1659,9 +1779,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1670,9 +1791,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1681,9 +1803,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1692,9 +1815,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1703,9 +1827,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1714,9 +1839,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1725,9 +1851,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1736,9 +1863,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1747,9 +1875,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1758,9 +1887,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1769,9 +1899,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1780,9 +1911,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1791,9 +1923,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1802,9 +1935,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1813,9 +1947,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1824,9 +1959,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1835,9 +1971,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1846,9 +1983,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1857,9 +1995,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1868,9 +2007,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1879,9 +2019,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1890,9 +2031,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1901,9 +2043,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1912,9 +2055,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1923,9 +2067,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1934,9 +2079,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1945,9 +2091,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1956,9 +2103,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1967,9 +2115,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1978,9 +2127,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1989,9 +2139,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2000,9 +2151,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2011,9 +2163,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2022,9 +2175,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2033,9 +2187,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2044,9 +2199,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2055,9 +2211,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2066,9 +2223,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2077,9 +2235,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2088,9 +2247,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2099,9 +2259,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2110,9 +2271,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2121,9 +2283,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2132,9 +2295,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2143,9 +2307,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2154,9 +2319,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2165,9 +2331,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2176,9 +2343,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2187,9 +2355,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2198,9 +2367,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2209,9 +2379,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2220,9 +2391,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2231,9 +2403,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2242,9 +2415,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2253,9 +2427,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2264,9 +2439,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2275,9 +2451,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2286,9 +2463,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2297,9 +2475,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2308,9 +2487,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2319,9 +2499,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2330,9 +2511,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2341,9 +2523,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2352,9 +2535,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2363,9 +2547,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2374,9 +2559,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2385,9 +2571,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2396,9 +2583,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2407,9 +2595,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2418,9 +2607,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2429,9 +2619,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2440,9 +2631,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2451,9 +2643,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2462,9 +2655,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2473,9 +2667,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2484,9 +2679,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2495,9 +2691,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2506,9 +2703,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2517,9 +2715,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2528,9 +2727,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2539,9 +2739,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2550,9 +2751,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2561,9 +2763,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2572,9 +2775,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2583,9 +2787,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2594,9 +2799,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2605,9 +2811,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2616,9 +2823,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2627,9 +2835,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2638,9 +2847,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2649,9 +2859,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2660,9 +2871,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2671,9 +2883,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2682,9 +2895,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2693,9 +2907,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2704,9 +2919,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2715,9 +2931,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2726,9 +2943,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2737,9 +2955,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2748,9 +2967,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2759,9 +2979,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2770,9 +2991,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2781,9 +3003,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2792,9 +3015,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2803,9 +3027,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2814,9 +3039,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2825,9 +3051,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2836,9 +3063,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2847,9 +3075,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2858,9 +3087,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2869,9 +3099,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2880,9 +3111,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2891,9 +3123,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2902,9 +3135,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2913,9 +3147,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2924,9 +3159,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2935,9 +3171,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2946,9 +3183,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2957,9 +3195,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2968,9 +3207,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2979,9 +3219,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2990,9 +3231,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3001,9 +3243,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3012,9 +3255,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3023,9 +3267,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3034,9 +3279,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3045,9 +3291,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3056,9 +3303,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3067,9 +3315,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3078,9 +3327,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3089,9 +3339,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3100,9 +3351,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3111,9 +3363,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3122,9 +3375,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3133,9 +3387,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3144,9 +3399,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3155,9 +3411,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3166,9 +3423,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3177,9 +3435,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3188,9 +3447,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3199,9 +3459,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3210,9 +3471,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3221,9 +3483,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3232,9 +3495,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3243,9 +3507,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3254,9 +3519,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3265,9 +3531,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3276,9 +3543,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3287,9 +3555,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3298,9 +3567,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3309,9 +3579,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3320,9 +3591,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3331,9 +3603,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3342,9 +3615,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3353,9 +3627,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3364,9 +3639,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3375,9 +3651,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3386,9 +3663,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3397,9 +3675,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3408,9 +3687,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3419,9 +3699,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3430,9 +3711,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3441,9 +3723,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3452,9 +3735,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3463,9 +3747,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3474,9 +3759,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3485,9 +3771,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3496,9 +3783,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3507,9 +3795,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3518,9 +3807,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3529,9 +3819,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3540,9 +3831,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3551,9 +3843,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3562,9 +3855,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3573,9 +3867,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3584,9 +3879,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3595,9 +3891,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3606,9 +3903,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3617,9 +3915,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3628,9 +3927,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3639,9 +3939,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3650,9 +3951,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3661,9 +3963,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3672,9 +3975,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3683,9 +3987,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3694,18 +3999,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -3714,9 +4021,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -3724,9 +4032,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -3737,9 +4046,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -390,162 +390,180 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {12})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {12}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {13})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {13}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {14})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {14}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {15})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {15}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {16})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {16}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, {17})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -554,9 +572,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -565,9 +584,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -576,9 +596,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -587,9 +608,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -598,9 +620,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -609,9 +632,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -620,9 +644,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -631,9 +656,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -642,9 +668,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -653,9 +680,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -664,9 +692,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -675,9 +704,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -686,9 +716,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -697,9 +728,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -708,9 +740,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -719,9 +752,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -730,9 +764,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -741,9 +776,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -752,9 +788,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -763,9 +800,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -774,9 +812,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -785,9 +824,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -796,9 +836,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -807,9 +848,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -818,9 +860,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -829,9 +872,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -840,9 +884,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -851,9 +896,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -862,9 +908,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -873,9 +920,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -884,9 +932,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -895,9 +944,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -906,9 +956,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -917,9 +968,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -928,9 +980,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -939,9 +992,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -950,9 +1004,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -961,9 +1016,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -972,9 +1028,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -983,9 +1040,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -994,9 +1052,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1005,9 +1064,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1016,9 +1076,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1027,9 +1088,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1038,9 +1100,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1049,9 +1112,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1060,9 +1124,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1071,9 +1136,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1082,9 +1148,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1093,9 +1160,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1104,9 +1172,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1115,9 +1184,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1126,9 +1196,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1137,9 +1208,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1148,9 +1220,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1159,9 +1232,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1170,9 +1244,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1181,9 +1256,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1192,9 +1268,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1203,9 +1280,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1214,9 +1292,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1225,9 +1304,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1236,9 +1316,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1247,9 +1328,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1258,9 +1340,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1269,9 +1352,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1280,9 +1364,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1291,9 +1376,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1302,9 +1388,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1313,9 +1400,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1324,9 +1412,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1335,9 +1424,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1346,9 +1436,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1357,9 +1448,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1368,9 +1460,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1379,9 +1472,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1390,9 +1484,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1401,9 +1496,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1412,9 +1508,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1423,9 +1520,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1434,9 +1532,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1445,9 +1544,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1456,9 +1556,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1467,9 +1568,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1478,9 +1580,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1489,9 +1592,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1500,9 +1604,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1511,9 +1616,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1522,9 +1628,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1533,9 +1640,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1544,9 +1652,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1555,9 +1664,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1566,9 +1676,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1577,9 +1688,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1588,9 +1700,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1599,9 +1712,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1610,9 +1724,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1621,9 +1736,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1632,9 +1748,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1643,9 +1760,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1654,9 +1772,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1665,9 +1784,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1676,9 +1796,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1687,9 +1808,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1698,9 +1820,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1709,9 +1832,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1720,9 +1844,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1731,9 +1856,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1742,9 +1868,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1753,9 +1880,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1764,9 +1892,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1775,9 +1904,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1786,9 +1916,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1797,9 +1928,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1808,9 +1940,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1819,9 +1952,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1830,9 +1964,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1841,9 +1976,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1852,9 +1988,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1863,9 +2000,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1874,9 +2012,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1885,9 +2024,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1896,9 +2036,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1907,9 +2048,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1918,9 +2060,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1929,9 +2072,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1940,9 +2084,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1951,9 +2096,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1962,9 +2108,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1973,9 +2120,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1984,9 +2132,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1995,9 +2144,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2006,9 +2156,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2017,9 +2168,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2028,9 +2180,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2039,9 +2192,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2050,9 +2204,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2061,9 +2216,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2072,9 +2228,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2083,9 +2240,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2094,9 +2252,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2105,9 +2264,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2116,9 +2276,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2127,9 +2288,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2138,9 +2300,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2149,9 +2312,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2160,9 +2324,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2171,9 +2336,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2182,9 +2348,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2193,9 +2360,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2204,9 +2372,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2215,9 +2384,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2226,9 +2396,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2237,9 +2408,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2248,9 +2420,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2259,9 +2432,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2270,9 +2444,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2281,9 +2456,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2292,9 +2468,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2303,9 +2480,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2314,9 +2492,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2325,9 +2504,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2336,9 +2516,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2347,9 +2528,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2358,9 +2540,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2369,9 +2552,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2380,9 +2564,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2391,9 +2576,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2402,9 +2588,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2413,9 +2600,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2424,9 +2612,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2435,9 +2624,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2446,9 +2636,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2457,9 +2648,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2468,9 +2660,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2479,9 +2672,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2490,9 +2684,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2501,9 +2696,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2512,9 +2708,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2523,9 +2720,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2534,9 +2732,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2545,9 +2744,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2556,9 +2756,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2567,9 +2768,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2578,9 +2780,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2589,9 +2792,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2600,9 +2804,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2611,9 +2816,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2622,9 +2828,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2633,9 +2840,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2644,9 +2852,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2655,9 +2864,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2666,9 +2876,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2677,9 +2888,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2688,9 +2900,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2699,9 +2912,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2710,9 +2924,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2721,9 +2936,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2732,9 +2948,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2743,9 +2960,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2754,9 +2972,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2765,9 +2984,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2776,9 +2996,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2787,9 +3008,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2798,9 +3020,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2809,9 +3032,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2820,9 +3044,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2831,9 +3056,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2842,9 +3068,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2853,9 +3080,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2864,9 +3092,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2875,9 +3104,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2886,9 +3116,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2897,9 +3128,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2908,9 +3140,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2919,9 +3152,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2930,9 +3164,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2941,9 +3176,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2952,9 +3188,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2963,9 +3200,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2974,9 +3212,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2985,9 +3224,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2996,9 +3236,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3007,9 +3248,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3018,9 +3260,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3029,9 +3272,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3040,9 +3284,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3051,9 +3296,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3062,9 +3308,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3073,9 +3320,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3084,9 +3332,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3095,9 +3344,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3106,9 +3356,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3117,9 +3368,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3128,9 +3380,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3139,9 +3392,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3150,9 +3404,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3161,9 +3416,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3172,9 +3428,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3183,9 +3440,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3194,9 +3452,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3205,9 +3464,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3216,9 +3476,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3227,9 +3488,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3238,9 +3500,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3249,9 +3512,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3260,9 +3524,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3271,9 +3536,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3282,9 +3548,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3293,9 +3560,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3304,9 +3572,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3315,9 +3584,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3326,9 +3596,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3337,9 +3608,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3348,9 +3620,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3359,9 +3632,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3370,9 +3644,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3381,9 +3656,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3392,9 +3668,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3403,9 +3680,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3414,9 +3692,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3425,9 +3704,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3436,9 +3716,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3447,9 +3728,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3458,9 +3740,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3469,9 +3752,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3480,9 +3764,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3491,9 +3776,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3502,9 +3788,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3513,9 +3800,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3524,9 +3812,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3535,9 +3824,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3546,9 +3836,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3557,9 +3848,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3568,9 +3860,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3579,9 +3872,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3590,9 +3884,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3601,9 +3896,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3612,9 +3908,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3623,9 +3920,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3634,9 +3932,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3645,9 +3944,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3656,9 +3956,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3667,9 +3968,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3678,9 +3980,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3689,9 +3992,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3700,9 +4004,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3711,9 +4016,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3722,9 +4028,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3733,9 +4040,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3744,9 +4052,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3755,9 +4064,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3766,9 +4076,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3777,9 +4088,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3788,9 +4100,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3799,9 +4112,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3810,9 +4124,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3821,9 +4136,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3832,9 +4148,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3843,9 +4160,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3854,9 +4172,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3865,9 +4184,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3876,9 +4196,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3887,9 +4208,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3898,9 +4220,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3909,9 +4232,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3920,9 +4244,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3931,9 +4256,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3942,9 +4268,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3953,9 +4280,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3964,9 +4292,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3975,9 +4304,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3986,9 +4316,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3997,9 +4328,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4008,9 +4340,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4019,9 +4352,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4030,9 +4364,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4041,9 +4376,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4052,9 +4388,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4063,9 +4400,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4074,9 +4412,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4085,9 +4424,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4096,9 +4436,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4107,18 +4448,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -4127,9 +4470,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -4137,9 +4481,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -4150,9 +4495,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -409,171 +409,190 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {12})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {12}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {13})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {13}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {14})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {14}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {15})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {15}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {16})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {16}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {17})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {17}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, {18})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -582,9 +601,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -593,9 +613,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -604,9 +625,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -615,9 +637,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -626,9 +649,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -637,9 +661,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -648,9 +673,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -659,9 +685,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -670,9 +697,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -681,9 +709,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -692,9 +721,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -703,9 +733,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -714,9 +745,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -725,9 +757,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -736,9 +769,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -747,9 +781,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -758,9 +793,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -769,9 +805,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -780,9 +817,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -791,9 +829,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -802,9 +841,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -813,9 +853,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -824,9 +865,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -835,9 +877,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -846,9 +889,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -857,9 +901,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -868,9 +913,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -879,9 +925,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -890,9 +937,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -901,9 +949,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -912,9 +961,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -923,9 +973,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -934,9 +985,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -945,9 +997,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -956,9 +1009,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -967,9 +1021,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -978,9 +1033,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -989,9 +1045,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1000,9 +1057,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1011,9 +1069,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1022,9 +1081,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1033,9 +1093,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1044,9 +1105,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1055,9 +1117,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1066,9 +1129,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1077,9 +1141,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1088,9 +1153,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1099,9 +1165,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1110,9 +1177,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1121,9 +1189,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1132,9 +1201,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1143,9 +1213,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1154,9 +1225,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1165,9 +1237,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1176,9 +1249,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1187,9 +1261,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1198,9 +1273,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1209,9 +1285,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1220,9 +1297,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1231,9 +1309,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1242,9 +1321,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1253,9 +1333,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1264,9 +1345,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1275,9 +1357,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1286,9 +1369,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1297,9 +1381,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1308,9 +1393,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1319,9 +1405,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1330,9 +1417,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1341,9 +1429,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1352,9 +1441,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1363,9 +1453,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1374,9 +1465,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1385,9 +1477,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1396,9 +1489,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1407,9 +1501,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1418,9 +1513,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1429,9 +1525,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1440,9 +1537,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1451,9 +1549,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1462,9 +1561,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1473,9 +1573,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1484,9 +1585,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1495,9 +1597,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1506,9 +1609,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1517,9 +1621,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1528,9 +1633,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1539,9 +1645,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1550,9 +1657,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1561,9 +1669,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1572,9 +1681,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1583,9 +1693,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1594,9 +1705,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1605,9 +1717,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1616,9 +1729,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1627,9 +1741,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1638,9 +1753,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1649,9 +1765,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1660,9 +1777,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1671,9 +1789,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1682,9 +1801,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1693,9 +1813,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1704,9 +1825,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1715,9 +1837,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1726,9 +1849,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1737,9 +1861,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1748,9 +1873,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1759,9 +1885,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1770,9 +1897,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1781,9 +1909,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1792,9 +1921,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1803,9 +1933,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1814,9 +1945,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1825,9 +1957,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1836,9 +1969,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1847,9 +1981,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1858,9 +1993,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1869,9 +2005,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1880,9 +2017,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1891,9 +2029,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1902,9 +2041,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1913,9 +2053,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1924,9 +2065,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1935,9 +2077,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1946,9 +2089,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1957,9 +2101,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1968,9 +2113,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1979,9 +2125,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1990,9 +2137,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2001,9 +2149,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2012,9 +2161,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2023,9 +2173,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2034,9 +2185,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2045,9 +2197,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2056,9 +2209,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2067,9 +2221,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2078,9 +2233,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2089,9 +2245,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2100,9 +2257,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2111,9 +2269,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2122,9 +2281,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2133,9 +2293,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2144,9 +2305,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2155,9 +2317,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2166,9 +2329,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2177,9 +2341,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2188,9 +2353,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2199,9 +2365,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2210,9 +2377,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2221,9 +2389,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2232,9 +2401,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2243,9 +2413,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2254,9 +2425,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2265,9 +2437,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2276,9 +2449,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2287,9 +2461,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2298,9 +2473,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2309,9 +2485,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2320,9 +2497,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2331,9 +2509,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2342,9 +2521,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2353,9 +2533,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2364,9 +2545,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2375,9 +2557,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2386,9 +2569,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2397,9 +2581,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2408,9 +2593,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2419,9 +2605,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2430,9 +2617,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2441,9 +2629,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2452,9 +2641,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2463,9 +2653,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2474,9 +2665,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2485,9 +2677,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2496,9 +2689,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2507,9 +2701,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2518,9 +2713,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2529,9 +2725,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2540,9 +2737,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2551,9 +2749,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2562,9 +2761,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2573,9 +2773,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2584,9 +2785,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2595,9 +2797,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2606,9 +2809,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2617,9 +2821,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2628,9 +2833,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2639,9 +2845,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2650,9 +2857,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2661,9 +2869,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2672,9 +2881,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2683,9 +2893,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2694,9 +2905,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2705,9 +2917,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2716,9 +2929,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2727,9 +2941,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2738,9 +2953,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2749,9 +2965,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2760,9 +2977,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2771,9 +2989,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2782,9 +3001,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2793,9 +3013,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2804,9 +3025,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2815,9 +3037,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2826,9 +3049,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2837,9 +3061,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2848,9 +3073,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2859,9 +3085,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2870,9 +3097,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2881,9 +3109,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2892,9 +3121,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2903,9 +3133,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2914,9 +3145,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2925,9 +3157,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2936,9 +3169,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2947,9 +3181,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2958,9 +3193,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2969,9 +3205,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2980,9 +3217,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2991,9 +3229,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3002,9 +3241,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3013,9 +3253,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3024,9 +3265,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3035,9 +3277,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3046,9 +3289,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3057,9 +3301,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3068,9 +3313,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3079,9 +3325,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3090,9 +3337,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3101,9 +3349,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3112,9 +3361,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3123,9 +3373,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3134,9 +3385,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3145,9 +3397,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3156,9 +3409,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3167,9 +3421,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3178,9 +3433,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3189,9 +3445,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3200,9 +3457,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3211,9 +3469,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3222,9 +3481,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3233,9 +3493,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3244,9 +3505,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3255,9 +3517,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3266,9 +3529,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3277,9 +3541,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3288,9 +3553,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3299,9 +3565,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3310,9 +3577,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3321,9 +3589,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3332,9 +3601,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3343,9 +3613,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3354,9 +3625,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3365,9 +3637,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3376,9 +3649,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3387,9 +3661,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3398,9 +3673,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3409,9 +3685,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3420,9 +3697,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3431,9 +3709,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3442,9 +3721,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3453,9 +3733,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3464,9 +3745,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3475,9 +3757,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3486,9 +3769,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3497,9 +3781,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3508,9 +3793,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3519,9 +3805,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3530,9 +3817,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3541,9 +3829,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3552,9 +3841,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3563,9 +3853,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3574,9 +3865,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3585,9 +3877,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3596,9 +3889,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3607,9 +3901,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3618,9 +3913,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3629,9 +3925,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3640,9 +3937,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3651,9 +3949,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3662,9 +3961,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3673,9 +3973,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3684,9 +3985,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3695,9 +3997,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3706,9 +4009,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3717,9 +4021,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3728,9 +4033,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3739,9 +4045,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3750,9 +4057,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3761,9 +4069,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3772,9 +4081,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3783,9 +4093,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3794,9 +4105,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3805,9 +4117,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3816,9 +4129,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3827,9 +4141,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3838,9 +4153,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3849,9 +4165,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3860,9 +4177,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3871,9 +4189,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3882,9 +4201,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3893,9 +4213,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3904,9 +4225,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3915,9 +4237,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3926,9 +4249,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3937,9 +4261,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3948,9 +4273,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3959,9 +4285,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3970,9 +4297,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3981,9 +4309,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3992,9 +4321,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4003,9 +4333,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4014,9 +4345,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4025,9 +4357,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4036,9 +4369,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4047,9 +4381,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4058,9 +4393,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4069,9 +4405,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4080,9 +4417,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4091,9 +4429,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4102,9 +4441,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4113,9 +4453,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4124,9 +4465,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4135,9 +4477,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4146,9 +4489,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4157,9 +4501,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4168,9 +4513,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4179,9 +4525,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4190,9 +4537,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4201,9 +4549,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4212,9 +4561,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4223,9 +4573,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4234,9 +4585,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4245,9 +4597,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4256,9 +4609,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4267,9 +4621,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4278,9 +4633,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4289,9 +4645,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4300,9 +4657,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4311,9 +4669,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4322,9 +4681,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4333,9 +4693,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4344,9 +4705,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4355,9 +4717,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4366,9 +4729,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4377,9 +4741,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4388,9 +4753,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4399,9 +4765,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4410,9 +4777,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4421,9 +4789,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4432,9 +4801,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4443,9 +4813,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4454,9 +4825,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4465,9 +4837,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4476,9 +4849,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4487,9 +4861,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4498,9 +4873,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4509,9 +4885,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4520,9 +4897,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4531,9 +4909,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4542,18 +4921,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -4562,9 +4943,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -4572,9 +4954,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -4585,9 +4968,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -428,180 +428,200 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {12})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {12}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {13})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {13}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {14})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {14}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {15})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {15}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {16})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {16}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {17})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {17}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {18})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {18}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T20))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, {19})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T20)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -610,9 +630,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -621,9 +642,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -632,9 +654,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -643,9 +666,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -654,9 +678,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -665,9 +690,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -676,9 +702,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -687,9 +714,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -698,9 +726,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -709,9 +738,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -720,9 +750,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -731,9 +762,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -742,9 +774,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -753,9 +786,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -764,9 +798,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -775,9 +810,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -786,9 +822,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -797,9 +834,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -808,9 +846,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -819,9 +858,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {0}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -830,9 +870,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -841,9 +882,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -852,9 +894,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -863,9 +906,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -874,9 +918,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -885,9 +930,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -896,9 +942,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -907,9 +954,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -918,9 +966,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -929,9 +978,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -940,9 +990,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -951,9 +1002,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -962,9 +1014,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -973,9 +1026,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -984,9 +1038,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -995,9 +1050,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1006,9 +1062,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1017,9 +1074,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1028,9 +1086,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1039,9 +1098,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {1}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1050,9 +1110,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1061,9 +1122,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1072,9 +1134,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1083,9 +1146,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1094,9 +1158,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1105,9 +1170,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1116,9 +1182,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1127,9 +1194,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1138,9 +1206,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1149,9 +1218,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1160,9 +1230,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1171,9 +1242,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1182,9 +1254,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1193,9 +1266,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1204,9 +1278,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1215,9 +1290,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1226,9 +1302,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1237,9 +1314,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1248,9 +1326,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1259,9 +1338,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {2}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1270,9 +1350,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1281,9 +1362,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1292,9 +1374,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1303,9 +1386,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1314,9 +1398,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1325,9 +1410,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1336,9 +1422,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1347,9 +1434,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1358,9 +1446,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1369,9 +1458,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1380,9 +1470,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1391,9 +1482,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1402,9 +1494,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1413,9 +1506,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1424,9 +1518,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1435,9 +1530,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1446,9 +1542,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1457,9 +1554,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1468,9 +1566,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1479,9 +1578,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {3}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1490,9 +1590,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1501,9 +1602,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1512,9 +1614,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1523,9 +1626,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1534,9 +1638,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1545,9 +1650,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1556,9 +1662,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1567,9 +1674,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1578,9 +1686,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1589,9 +1698,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1600,9 +1710,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1611,9 +1722,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1622,9 +1734,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1633,9 +1746,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1644,9 +1758,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1655,9 +1770,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1666,9 +1782,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1677,9 +1794,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1688,9 +1806,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1699,9 +1818,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {4}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1710,9 +1830,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1721,9 +1842,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1732,9 +1854,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1743,9 +1866,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1754,9 +1878,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1765,9 +1890,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1776,9 +1902,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1787,9 +1914,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1798,9 +1926,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1809,9 +1938,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1820,9 +1950,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1831,9 +1962,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1842,9 +1974,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1853,9 +1986,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1864,9 +1998,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1875,9 +2010,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1886,9 +2022,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1897,9 +2034,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1908,9 +2046,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1919,9 +2058,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {5}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1930,9 +2070,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1941,9 +2082,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1952,9 +2094,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1963,9 +2106,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1974,9 +2118,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1985,9 +2130,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1996,9 +2142,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2007,9 +2154,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2018,9 +2166,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2029,9 +2178,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2040,9 +2190,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2051,9 +2202,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2062,9 +2214,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2073,9 +2226,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2084,9 +2238,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2095,9 +2250,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2106,9 +2262,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2117,9 +2274,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2128,9 +2286,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2139,9 +2298,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {6}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2150,9 +2310,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2161,9 +2322,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2172,9 +2334,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2183,9 +2346,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2194,9 +2358,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2205,9 +2370,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2216,9 +2382,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2227,9 +2394,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2238,9 +2406,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2249,9 +2418,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2260,9 +2430,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2271,9 +2442,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2282,9 +2454,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2293,9 +2466,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2304,9 +2478,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2315,9 +2490,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2326,9 +2502,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2337,9 +2514,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2348,9 +2526,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2359,9 +2538,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {7}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2370,9 +2550,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2381,9 +2562,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2392,9 +2574,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2403,9 +2586,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2414,9 +2598,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2425,9 +2610,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2436,9 +2622,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2447,9 +2634,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2458,9 +2646,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2469,9 +2658,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2480,9 +2670,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2491,9 +2682,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2502,9 +2694,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2513,9 +2706,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2524,9 +2718,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2535,9 +2730,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2546,9 +2742,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2557,9 +2754,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2568,9 +2766,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2579,9 +2778,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {8}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2590,9 +2790,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2601,9 +2802,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2612,9 +2814,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2623,9 +2826,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2634,9 +2838,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2645,9 +2850,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2656,9 +2862,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2667,9 +2874,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2678,9 +2886,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2689,9 +2898,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2700,9 +2910,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2711,9 +2922,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2722,9 +2934,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2733,9 +2946,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2744,9 +2958,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2755,9 +2970,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2766,9 +2982,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2777,9 +2994,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2788,9 +3006,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2799,9 +3018,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {9}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2810,9 +3030,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2821,9 +3042,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2832,9 +3054,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2843,9 +3066,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2854,9 +3078,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2865,9 +3090,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2876,9 +3102,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2887,9 +3114,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2898,9 +3126,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2909,9 +3138,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2920,9 +3150,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2931,9 +3162,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2942,9 +3174,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2953,9 +3186,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2964,9 +3198,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2975,9 +3210,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2986,9 +3222,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2997,9 +3234,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3008,9 +3246,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3019,9 +3258,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {10}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3030,9 +3270,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3041,9 +3282,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3052,9 +3294,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3063,9 +3306,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3074,9 +3318,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3085,9 +3330,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3096,9 +3342,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3107,9 +3354,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3118,9 +3366,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3129,9 +3378,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3140,9 +3390,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3151,9 +3402,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3162,9 +3414,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3173,9 +3426,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3184,9 +3438,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3195,9 +3450,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3206,9 +3462,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3217,9 +3474,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3228,9 +3486,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3239,9 +3498,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {11}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3250,9 +3510,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3261,9 +3522,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3272,9 +3534,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3283,9 +3546,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3294,9 +3558,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3305,9 +3570,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3316,9 +3582,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3327,9 +3594,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3338,9 +3606,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3349,9 +3618,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3360,9 +3630,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3371,9 +3642,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3382,9 +3654,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3393,9 +3666,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3404,9 +3678,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3415,9 +3690,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3426,9 +3702,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3437,9 +3714,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3448,9 +3726,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3459,9 +3738,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {12}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3470,9 +3750,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3481,9 +3762,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3492,9 +3774,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3503,9 +3786,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3514,9 +3798,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3525,9 +3810,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3536,9 +3822,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3547,9 +3834,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3558,9 +3846,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3569,9 +3858,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3580,9 +3870,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3591,9 +3882,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3602,9 +3894,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3613,9 +3906,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3624,9 +3918,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3635,9 +3930,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3646,9 +3942,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3657,9 +3954,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3668,9 +3966,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3679,9 +3978,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {13}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3690,9 +3990,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3701,9 +4002,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3712,9 +4014,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3723,9 +4026,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3734,9 +4038,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3745,9 +4050,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3756,9 +4062,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3767,9 +4074,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3778,9 +4086,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3789,9 +4098,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3800,9 +4110,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3811,9 +4122,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3822,9 +4134,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3833,9 +4146,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3844,9 +4158,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3855,9 +4170,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3866,9 +4182,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3877,9 +4194,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3888,9 +4206,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3899,9 +4218,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {14}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3910,9 +4230,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3921,9 +4242,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3932,9 +4254,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3943,9 +4266,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3954,9 +4278,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3965,9 +4290,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3976,9 +4302,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3987,9 +4314,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3998,9 +4326,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4009,9 +4338,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4020,9 +4350,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4031,9 +4362,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4042,9 +4374,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4053,9 +4386,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4064,9 +4398,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4075,9 +4410,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4086,9 +4422,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4097,9 +4434,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4108,9 +4446,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4119,9 +4458,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {15}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4130,9 +4470,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4141,9 +4482,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4152,9 +4494,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4163,9 +4506,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4174,9 +4518,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4185,9 +4530,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4196,9 +4542,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4207,9 +4554,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4218,9 +4566,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4229,9 +4578,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4240,9 +4590,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4251,9 +4602,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4262,9 +4614,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4273,9 +4626,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4284,9 +4638,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4295,9 +4650,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4306,9 +4662,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4317,9 +4674,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4328,9 +4686,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4339,9 +4698,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {16}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4350,9 +4710,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4361,9 +4722,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4372,9 +4734,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4383,9 +4746,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4394,9 +4758,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4405,9 +4770,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4416,9 +4782,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4427,9 +4794,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4438,9 +4806,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4449,9 +4818,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4460,9 +4830,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4471,9 +4842,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4482,9 +4854,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4493,9 +4866,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4504,9 +4878,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4515,9 +4890,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4526,9 +4902,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4537,9 +4914,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4548,9 +4926,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4559,9 +4938,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {17}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4570,9 +4950,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4581,9 +4962,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4592,9 +4974,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4603,9 +4986,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4614,9 +4998,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4625,9 +5010,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4636,9 +5022,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4647,9 +5034,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4658,9 +5046,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4669,9 +5058,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4680,9 +5070,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4691,9 +5082,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4702,9 +5094,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4713,9 +5106,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4724,9 +5118,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4735,9 +5130,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4746,9 +5142,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4757,9 +5154,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4768,9 +5166,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4779,9 +5178,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {18}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4790,9 +5190,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4801,9 +5202,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4812,9 +5214,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4823,9 +5226,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4834,9 +5238,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4845,9 +5250,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4856,9 +5262,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4867,9 +5274,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4878,9 +5286,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4889,9 +5298,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4900,9 +5310,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4911,9 +5322,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4922,9 +5334,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4933,9 +5346,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4944,9 +5358,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4955,9 +5370,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4966,9 +5382,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4977,9 +5394,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4988,9 +5406,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4999,18 +5418,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, {19}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {19}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -5019,9 +5440,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -5029,9 +5451,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -5042,9 +5465,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -447,189 +447,210 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {12})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {12}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {13})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {13}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {14})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {14}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {15})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {15}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {16})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {16}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {17})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {17}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {18})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {18}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T20))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {19})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T20)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {19}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T21))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, {20})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T21)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -638,9 +659,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -649,9 +671,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -660,9 +683,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -671,9 +695,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -682,9 +707,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -693,9 +719,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -704,9 +731,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -715,9 +743,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -726,9 +755,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -737,9 +767,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -748,9 +779,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -759,9 +791,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -770,9 +803,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -781,9 +815,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -792,9 +827,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -803,9 +839,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -814,9 +851,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -825,9 +863,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -836,9 +875,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -847,9 +887,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -858,9 +899,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {0}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -869,9 +911,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -880,9 +923,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -891,9 +935,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -902,9 +947,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -913,9 +959,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -924,9 +971,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -935,9 +983,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -946,9 +995,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -957,9 +1007,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -968,9 +1019,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -979,9 +1031,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -990,9 +1043,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1001,9 +1055,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1012,9 +1067,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1023,9 +1079,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1034,9 +1091,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1045,9 +1103,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1056,9 +1115,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1067,9 +1127,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1078,9 +1139,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1089,9 +1151,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {1}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1100,9 +1163,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1111,9 +1175,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1122,9 +1187,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1133,9 +1199,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1144,9 +1211,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1155,9 +1223,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1166,9 +1235,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1177,9 +1247,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1188,9 +1259,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1199,9 +1271,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1210,9 +1283,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1221,9 +1295,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1232,9 +1307,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1243,9 +1319,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1254,9 +1331,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1265,9 +1343,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1276,9 +1355,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1287,9 +1367,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1298,9 +1379,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1309,9 +1391,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1320,9 +1403,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {2}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1331,9 +1415,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1342,9 +1427,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1353,9 +1439,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1364,9 +1451,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1375,9 +1463,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1386,9 +1475,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1397,9 +1487,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1408,9 +1499,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1419,9 +1511,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1430,9 +1523,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1441,9 +1535,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1452,9 +1547,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1463,9 +1559,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1474,9 +1571,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1485,9 +1583,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1496,9 +1595,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1507,9 +1607,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1518,9 +1619,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1529,9 +1631,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1540,9 +1643,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1551,9 +1655,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {3}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1562,9 +1667,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1573,9 +1679,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1584,9 +1691,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1595,9 +1703,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1606,9 +1715,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1617,9 +1727,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1628,9 +1739,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1639,9 +1751,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1650,9 +1763,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1661,9 +1775,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1672,9 +1787,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1683,9 +1799,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1694,9 +1811,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1705,9 +1823,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1716,9 +1835,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1727,9 +1847,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1738,9 +1859,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1749,9 +1871,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1760,9 +1883,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1771,9 +1895,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1782,9 +1907,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {4}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1793,9 +1919,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1804,9 +1931,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1815,9 +1943,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1826,9 +1955,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1837,9 +1967,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1848,9 +1979,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1859,9 +1991,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1870,9 +2003,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1881,9 +2015,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1892,9 +2027,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1903,9 +2039,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1914,9 +2051,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1925,9 +2063,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1936,9 +2075,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1947,9 +2087,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1958,9 +2099,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1969,9 +2111,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1980,9 +2123,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1991,9 +2135,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2002,9 +2147,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2013,9 +2159,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {5}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2024,9 +2171,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2035,9 +2183,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2046,9 +2195,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2057,9 +2207,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2068,9 +2219,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2079,9 +2231,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2090,9 +2243,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2101,9 +2255,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2112,9 +2267,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2123,9 +2279,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2134,9 +2291,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2145,9 +2303,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2156,9 +2315,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2167,9 +2327,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2178,9 +2339,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2189,9 +2351,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2200,9 +2363,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2211,9 +2375,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2222,9 +2387,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2233,9 +2399,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2244,9 +2411,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {6}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2255,9 +2423,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2266,9 +2435,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2277,9 +2447,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2288,9 +2459,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2299,9 +2471,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2310,9 +2483,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2321,9 +2495,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2332,9 +2507,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2343,9 +2519,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2354,9 +2531,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2365,9 +2543,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2376,9 +2555,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2387,9 +2567,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2398,9 +2579,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2409,9 +2591,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2420,9 +2603,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2431,9 +2615,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2442,9 +2627,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2453,9 +2639,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2464,9 +2651,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2475,9 +2663,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {7}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2486,9 +2675,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2497,9 +2687,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2508,9 +2699,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2519,9 +2711,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2530,9 +2723,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2541,9 +2735,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2552,9 +2747,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2563,9 +2759,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2574,9 +2771,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2585,9 +2783,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2596,9 +2795,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2607,9 +2807,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2618,9 +2819,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2629,9 +2831,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2640,9 +2843,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2651,9 +2855,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2662,9 +2867,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2673,9 +2879,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2684,9 +2891,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2695,9 +2903,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2706,9 +2915,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {8}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2717,9 +2927,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2728,9 +2939,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2739,9 +2951,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2750,9 +2963,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2761,9 +2975,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2772,9 +2987,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2783,9 +2999,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2794,9 +3011,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2805,9 +3023,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2816,9 +3035,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2827,9 +3047,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2838,9 +3059,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2849,9 +3071,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2860,9 +3083,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2871,9 +3095,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2882,9 +3107,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2893,9 +3119,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2904,9 +3131,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2915,9 +3143,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2926,9 +3155,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2937,9 +3167,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {9}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2948,9 +3179,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2959,9 +3191,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2970,9 +3203,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2981,9 +3215,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2992,9 +3227,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3003,9 +3239,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3014,9 +3251,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3025,9 +3263,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3036,9 +3275,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3047,9 +3287,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3058,9 +3299,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3069,9 +3311,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3080,9 +3323,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3091,9 +3335,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3102,9 +3347,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3113,9 +3359,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3124,9 +3371,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3135,9 +3383,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3146,9 +3395,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3157,9 +3407,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3168,9 +3419,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {10}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3179,9 +3431,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3190,9 +3443,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3201,9 +3455,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3212,9 +3467,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3223,9 +3479,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3234,9 +3491,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3245,9 +3503,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3256,9 +3515,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3267,9 +3527,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3278,9 +3539,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3289,9 +3551,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3300,9 +3563,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3311,9 +3575,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3322,9 +3587,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3333,9 +3599,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3344,9 +3611,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3355,9 +3623,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3366,9 +3635,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3377,9 +3647,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3388,9 +3659,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3399,9 +3671,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {11}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3410,9 +3683,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3421,9 +3695,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3432,9 +3707,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3443,9 +3719,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3454,9 +3731,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3465,9 +3743,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3476,9 +3755,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3487,9 +3767,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3498,9 +3779,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3509,9 +3791,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3520,9 +3803,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3531,9 +3815,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3542,9 +3827,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3553,9 +3839,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3564,9 +3851,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3575,9 +3863,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3586,9 +3875,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3597,9 +3887,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3608,9 +3899,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3619,9 +3911,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3630,9 +3923,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {12}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3641,9 +3935,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3652,9 +3947,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3663,9 +3959,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3674,9 +3971,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3685,9 +3983,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3696,9 +3995,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3707,9 +4007,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3718,9 +4019,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3729,9 +4031,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3740,9 +4043,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3751,9 +4055,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3762,9 +4067,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3773,9 +4079,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3784,9 +4091,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3795,9 +4103,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3806,9 +4115,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3817,9 +4127,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3828,9 +4139,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3839,9 +4151,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3850,9 +4163,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3861,9 +4175,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {13}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3872,9 +4187,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3883,9 +4199,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3894,9 +4211,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3905,9 +4223,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3916,9 +4235,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3927,9 +4247,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3938,9 +4259,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3949,9 +4271,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3960,9 +4283,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3971,9 +4295,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3982,9 +4307,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3993,9 +4319,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4004,9 +4331,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4015,9 +4343,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4026,9 +4355,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4037,9 +4367,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4048,9 +4379,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4059,9 +4391,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4070,9 +4403,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4081,9 +4415,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4092,9 +4427,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {14}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4103,9 +4439,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4114,9 +4451,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4125,9 +4463,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4136,9 +4475,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4147,9 +4487,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4158,9 +4499,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4169,9 +4511,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4180,9 +4523,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4191,9 +4535,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4202,9 +4547,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4213,9 +4559,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4224,9 +4571,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4235,9 +4583,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4246,9 +4595,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4257,9 +4607,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4268,9 +4619,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4279,9 +4631,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4290,9 +4643,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4301,9 +4655,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4312,9 +4667,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4323,9 +4679,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {15}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4334,9 +4691,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4345,9 +4703,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4356,9 +4715,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4367,9 +4727,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4378,9 +4739,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4389,9 +4751,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4400,9 +4763,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4411,9 +4775,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4422,9 +4787,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4433,9 +4799,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4444,9 +4811,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4455,9 +4823,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4466,9 +4835,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4477,9 +4847,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4488,9 +4859,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4499,9 +4871,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4510,9 +4883,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4521,9 +4895,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4532,9 +4907,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4543,9 +4919,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4554,9 +4931,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {16}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4565,9 +4943,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4576,9 +4955,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4587,9 +4967,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4598,9 +4979,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4609,9 +4991,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4620,9 +5003,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4631,9 +5015,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4642,9 +5027,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4653,9 +5039,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4664,9 +5051,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4675,9 +5063,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4686,9 +5075,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4697,9 +5087,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4708,9 +5099,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4719,9 +5111,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4730,9 +5123,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4741,9 +5135,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4752,9 +5147,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4763,9 +5159,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4774,9 +5171,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4785,9 +5183,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {17}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4796,9 +5195,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4807,9 +5207,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4818,9 +5219,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4829,9 +5231,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4840,9 +5243,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4851,9 +5255,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4862,9 +5267,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4873,9 +5279,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4884,9 +5291,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4895,9 +5303,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4906,9 +5315,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4917,9 +5327,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4928,9 +5339,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4939,9 +5351,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4950,9 +5363,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4961,9 +5375,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4972,9 +5387,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4983,9 +5399,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4994,9 +5411,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5005,9 +5423,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5016,9 +5435,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {18}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5027,9 +5447,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5038,9 +5459,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5049,9 +5471,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5060,9 +5483,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5071,9 +5495,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5082,9 +5507,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5093,9 +5519,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5104,9 +5531,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5115,9 +5543,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5126,9 +5555,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5137,9 +5567,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5148,9 +5579,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5159,9 +5591,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5170,9 +5603,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5181,9 +5615,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5192,9 +5627,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5203,9 +5639,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5214,9 +5651,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5225,9 +5663,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5236,9 +5675,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5247,9 +5687,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {19}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5258,9 +5699,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5269,9 +5711,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5280,9 +5723,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5291,9 +5735,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5302,9 +5747,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5313,9 +5759,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5324,9 +5771,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5335,9 +5783,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5346,9 +5795,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5357,9 +5807,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5368,9 +5819,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5379,9 +5831,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5390,9 +5843,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5401,9 +5855,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5412,9 +5867,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5423,9 +5879,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5434,9 +5891,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5445,9 +5903,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5456,9 +5915,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5467,9 +5927,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5478,18 +5939,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, {20}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {20}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -5498,9 +5961,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -5508,9 +5972,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -5521,9 +5986,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -466,198 +466,220 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {12})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {12}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {13})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {13}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {14})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {14}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {15})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {15}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {16})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {16}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {17})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {17}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {18})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {18}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T20))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {19})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T20)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {19}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T21))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {20})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T21)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {20}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T22))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, {21})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T22)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -666,9 +688,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -677,9 +700,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -688,9 +712,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -699,9 +724,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -710,9 +736,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -721,9 +748,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -732,9 +760,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -743,9 +772,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -754,9 +784,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -765,9 +796,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -776,9 +808,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -787,9 +820,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -798,9 +832,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -809,9 +844,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -820,9 +856,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -831,9 +868,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -842,9 +880,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -853,9 +892,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -864,9 +904,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -875,9 +916,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -886,9 +928,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -897,9 +940,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {0}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -908,9 +952,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -919,9 +964,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -930,9 +976,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -941,9 +988,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -952,9 +1000,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -963,9 +1012,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -974,9 +1024,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -985,9 +1036,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -996,9 +1048,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1007,9 +1060,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1018,9 +1072,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1029,9 +1084,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1040,9 +1096,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1051,9 +1108,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1062,9 +1120,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1073,9 +1132,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1084,9 +1144,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1095,9 +1156,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1106,9 +1168,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1117,9 +1180,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1128,9 +1192,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1139,9 +1204,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {1}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1150,9 +1216,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1161,9 +1228,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1172,9 +1240,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1183,9 +1252,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1194,9 +1264,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1205,9 +1276,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1216,9 +1288,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1227,9 +1300,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1238,9 +1312,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1249,9 +1324,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1260,9 +1336,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1271,9 +1348,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1282,9 +1360,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1293,9 +1372,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1304,9 +1384,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1315,9 +1396,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1326,9 +1408,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1337,9 +1420,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1348,9 +1432,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1359,9 +1444,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1370,9 +1456,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1381,9 +1468,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {2}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1392,9 +1480,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1403,9 +1492,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1414,9 +1504,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1425,9 +1516,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1436,9 +1528,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1447,9 +1540,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1458,9 +1552,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1469,9 +1564,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1480,9 +1576,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1491,9 +1588,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1502,9 +1600,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1513,9 +1612,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1524,9 +1624,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1535,9 +1636,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1546,9 +1648,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1557,9 +1660,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1568,9 +1672,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1579,9 +1684,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1590,9 +1696,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1601,9 +1708,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1612,9 +1720,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1623,9 +1732,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {3}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1634,9 +1744,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1645,9 +1756,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1656,9 +1768,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1667,9 +1780,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1678,9 +1792,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1689,9 +1804,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1700,9 +1816,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1711,9 +1828,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1722,9 +1840,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1733,9 +1852,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1744,9 +1864,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1755,9 +1876,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1766,9 +1888,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1777,9 +1900,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1788,9 +1912,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1799,9 +1924,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1810,9 +1936,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1821,9 +1948,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1832,9 +1960,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1843,9 +1972,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1854,9 +1984,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1865,9 +1996,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {4}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1876,9 +2008,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1887,9 +2020,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1898,9 +2032,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1909,9 +2044,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1920,9 +2056,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1931,9 +2068,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1942,9 +2080,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1953,9 +2092,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1964,9 +2104,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1975,9 +2116,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1986,9 +2128,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1997,9 +2140,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2008,9 +2152,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2019,9 +2164,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2030,9 +2176,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2041,9 +2188,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2052,9 +2200,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2063,9 +2212,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2074,9 +2224,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2085,9 +2236,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2096,9 +2248,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2107,9 +2260,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {5}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2118,9 +2272,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2129,9 +2284,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2140,9 +2296,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2151,9 +2308,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2162,9 +2320,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2173,9 +2332,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2184,9 +2344,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2195,9 +2356,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2206,9 +2368,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2217,9 +2380,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2228,9 +2392,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2239,9 +2404,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2250,9 +2416,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2261,9 +2428,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2272,9 +2440,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2283,9 +2452,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2294,9 +2464,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2305,9 +2476,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2316,9 +2488,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2327,9 +2500,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2338,9 +2512,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2349,9 +2524,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {6}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2360,9 +2536,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2371,9 +2548,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2382,9 +2560,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2393,9 +2572,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2404,9 +2584,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2415,9 +2596,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2426,9 +2608,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2437,9 +2620,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2448,9 +2632,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2459,9 +2644,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2470,9 +2656,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2481,9 +2668,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2492,9 +2680,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2503,9 +2692,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2514,9 +2704,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2525,9 +2716,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2536,9 +2728,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2547,9 +2740,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2558,9 +2752,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2569,9 +2764,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2580,9 +2776,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2591,9 +2788,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {7}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2602,9 +2800,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2613,9 +2812,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2624,9 +2824,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2635,9 +2836,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2646,9 +2848,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2657,9 +2860,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2668,9 +2872,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2679,9 +2884,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2690,9 +2896,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2701,9 +2908,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2712,9 +2920,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2723,9 +2932,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2734,9 +2944,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2745,9 +2956,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2756,9 +2968,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2767,9 +2980,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2778,9 +2992,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2789,9 +3004,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2800,9 +3016,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2811,9 +3028,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2822,9 +3040,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2833,9 +3052,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {8}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2844,9 +3064,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2855,9 +3076,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2866,9 +3088,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2877,9 +3100,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2888,9 +3112,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2899,9 +3124,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2910,9 +3136,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2921,9 +3148,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2932,9 +3160,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2943,9 +3172,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2954,9 +3184,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2965,9 +3196,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2976,9 +3208,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2987,9 +3220,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2998,9 +3232,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3009,9 +3244,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3020,9 +3256,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3031,9 +3268,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3042,9 +3280,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3053,9 +3292,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3064,9 +3304,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3075,9 +3316,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {9}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3086,9 +3328,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3097,9 +3340,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3108,9 +3352,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3119,9 +3364,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3130,9 +3376,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3141,9 +3388,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3152,9 +3400,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3163,9 +3412,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3174,9 +3424,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3185,9 +3436,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3196,9 +3448,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3207,9 +3460,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3218,9 +3472,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3229,9 +3484,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3240,9 +3496,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3251,9 +3508,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3262,9 +3520,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3273,9 +3532,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3284,9 +3544,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3295,9 +3556,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3306,9 +3568,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3317,9 +3580,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {10}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3328,9 +3592,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3339,9 +3604,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3350,9 +3616,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3361,9 +3628,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3372,9 +3640,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3383,9 +3652,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3394,9 +3664,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3405,9 +3676,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3416,9 +3688,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3427,9 +3700,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3438,9 +3712,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3449,9 +3724,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3460,9 +3736,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3471,9 +3748,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3482,9 +3760,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3493,9 +3772,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3504,9 +3784,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3515,9 +3796,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3526,9 +3808,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3537,9 +3820,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3548,9 +3832,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3559,9 +3844,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {11}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3570,9 +3856,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3581,9 +3868,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3592,9 +3880,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3603,9 +3892,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3614,9 +3904,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3625,9 +3916,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3636,9 +3928,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3647,9 +3940,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3658,9 +3952,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3669,9 +3964,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3680,9 +3976,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3691,9 +3988,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3702,9 +4000,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3713,9 +4012,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3724,9 +4024,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3735,9 +4036,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3746,9 +4048,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3757,9 +4060,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3768,9 +4072,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3779,9 +4084,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3790,9 +4096,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3801,9 +4108,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {12}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3812,9 +4120,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3823,9 +4132,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3834,9 +4144,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3845,9 +4156,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3856,9 +4168,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3867,9 +4180,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3878,9 +4192,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3889,9 +4204,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3900,9 +4216,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3911,9 +4228,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3922,9 +4240,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3933,9 +4252,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3944,9 +4264,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3955,9 +4276,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3966,9 +4288,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3977,9 +4300,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3988,9 +4312,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3999,9 +4324,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4010,9 +4336,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4021,9 +4348,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4032,9 +4360,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4043,9 +4372,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {13}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4054,9 +4384,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4065,9 +4396,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4076,9 +4408,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4087,9 +4420,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4098,9 +4432,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4109,9 +4444,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4120,9 +4456,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4131,9 +4468,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4142,9 +4480,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4153,9 +4492,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4164,9 +4504,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4175,9 +4516,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4186,9 +4528,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4197,9 +4540,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4208,9 +4552,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4219,9 +4564,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4230,9 +4576,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4241,9 +4588,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4252,9 +4600,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4263,9 +4612,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4274,9 +4624,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4285,9 +4636,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {14}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4296,9 +4648,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4307,9 +4660,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4318,9 +4672,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4329,9 +4684,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4340,9 +4696,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4351,9 +4708,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4362,9 +4720,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4373,9 +4732,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4384,9 +4744,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4395,9 +4756,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4406,9 +4768,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4417,9 +4780,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4428,9 +4792,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4439,9 +4804,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4450,9 +4816,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4461,9 +4828,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4472,9 +4840,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4483,9 +4852,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4494,9 +4864,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4505,9 +4876,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4516,9 +4888,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4527,9 +4900,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {15}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4538,9 +4912,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4549,9 +4924,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4560,9 +4936,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4571,9 +4948,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4582,9 +4960,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4593,9 +4972,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4604,9 +4984,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4615,9 +4996,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4626,9 +5008,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4637,9 +5020,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4648,9 +5032,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4659,9 +5044,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4670,9 +5056,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4681,9 +5068,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4692,9 +5080,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4703,9 +5092,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4714,9 +5104,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4725,9 +5116,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4736,9 +5128,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4747,9 +5140,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4758,9 +5152,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4769,9 +5164,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {16}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4780,9 +5176,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4791,9 +5188,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4802,9 +5200,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4813,9 +5212,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4824,9 +5224,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4835,9 +5236,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4846,9 +5248,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4857,9 +5260,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4868,9 +5272,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4879,9 +5284,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4890,9 +5296,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4901,9 +5308,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4912,9 +5320,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4923,9 +5332,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4934,9 +5344,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4945,9 +5356,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4956,9 +5368,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4967,9 +5380,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4978,9 +5392,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4989,9 +5404,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5000,9 +5416,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5011,9 +5428,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {17}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5022,9 +5440,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5033,9 +5452,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5044,9 +5464,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5055,9 +5476,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5066,9 +5488,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5077,9 +5500,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5088,9 +5512,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5099,9 +5524,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5110,9 +5536,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5121,9 +5548,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5132,9 +5560,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5143,9 +5572,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5154,9 +5584,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5165,9 +5596,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5176,9 +5608,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5187,9 +5620,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5198,9 +5632,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5209,9 +5644,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5220,9 +5656,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5231,9 +5668,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5242,9 +5680,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5253,9 +5692,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {18}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5264,9 +5704,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5275,9 +5716,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5286,9 +5728,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5297,9 +5740,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5308,9 +5752,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5319,9 +5764,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5330,9 +5776,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5341,9 +5788,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5352,9 +5800,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5363,9 +5812,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5374,9 +5824,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5385,9 +5836,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5396,9 +5848,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5407,9 +5860,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5418,9 +5872,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5429,9 +5884,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5440,9 +5896,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5451,9 +5908,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5462,9 +5920,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5473,9 +5932,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5484,9 +5944,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5495,9 +5956,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {19}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5506,9 +5968,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5517,9 +5980,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5528,9 +5992,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5539,9 +6004,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5550,9 +6016,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5561,9 +6028,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5572,9 +6040,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5583,9 +6052,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5594,9 +6064,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5605,9 +6076,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5616,9 +6088,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5627,9 +6100,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5638,9 +6112,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5649,9 +6124,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5660,9 +6136,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5671,9 +6148,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5682,9 +6160,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5693,9 +6172,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5704,9 +6184,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5715,9 +6196,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5726,9 +6208,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5737,9 +6220,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {20}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5748,9 +6232,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5759,9 +6244,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5770,9 +6256,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5781,9 +6268,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5792,9 +6280,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5803,9 +6292,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5814,9 +6304,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5825,9 +6316,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5836,9 +6328,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5847,9 +6340,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5858,9 +6352,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5869,9 +6364,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5880,9 +6376,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5891,9 +6388,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5902,9 +6400,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5913,9 +6412,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5924,9 +6424,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5935,9 +6436,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5946,9 +6448,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5957,9 +6460,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5968,9 +6472,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5979,18 +6484,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, {21}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {21}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -5999,9 +6506,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -6009,9 +6517,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -6022,9 +6531,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -485,207 +485,230 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {12})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {12}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {13})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {13}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {14})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {14}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {15})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {15}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {16})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {16}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {17})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {17}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {18})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {18}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T20))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {19})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T20)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {19}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T21))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {20})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T21)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {20}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T22))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {21})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T22)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {21}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T23))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, {22})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T23)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -694,9 +717,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -705,9 +729,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -716,9 +741,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -727,9 +753,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -738,9 +765,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -749,9 +777,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -760,9 +789,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -771,9 +801,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -782,9 +813,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -793,9 +825,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -804,9 +837,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -815,9 +849,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -826,9 +861,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -837,9 +873,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -848,9 +885,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -859,9 +897,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -870,9 +909,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -881,9 +921,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -892,9 +933,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -903,9 +945,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -914,9 +957,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -925,9 +969,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -936,9 +981,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {0}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -947,9 +993,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -958,9 +1005,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -969,9 +1017,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -980,9 +1029,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -991,9 +1041,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1002,9 +1053,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1013,9 +1065,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1024,9 +1077,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1035,9 +1089,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1046,9 +1101,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1057,9 +1113,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1068,9 +1125,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1079,9 +1137,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1090,9 +1149,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1101,9 +1161,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1112,9 +1173,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1123,9 +1185,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1134,9 +1197,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1145,9 +1209,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1156,9 +1221,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1167,9 +1233,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1178,9 +1245,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1189,9 +1257,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {1}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1200,9 +1269,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1211,9 +1281,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1222,9 +1293,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1233,9 +1305,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1244,9 +1317,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1255,9 +1329,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1266,9 +1341,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1277,9 +1353,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1288,9 +1365,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1299,9 +1377,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1310,9 +1389,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1321,9 +1401,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1332,9 +1413,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1343,9 +1425,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1354,9 +1437,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1365,9 +1449,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1376,9 +1461,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1387,9 +1473,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1398,9 +1485,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1409,9 +1497,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1420,9 +1509,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1431,9 +1521,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1442,9 +1533,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {2}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1453,9 +1545,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1464,9 +1557,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1475,9 +1569,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1486,9 +1581,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1497,9 +1593,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1508,9 +1605,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1519,9 +1617,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1530,9 +1629,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1541,9 +1641,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1552,9 +1653,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1563,9 +1665,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1574,9 +1677,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1585,9 +1689,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1596,9 +1701,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1607,9 +1713,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1618,9 +1725,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1629,9 +1737,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1640,9 +1749,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1651,9 +1761,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1662,9 +1773,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1673,9 +1785,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1684,9 +1797,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1695,9 +1809,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {3}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1706,9 +1821,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1717,9 +1833,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1728,9 +1845,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1739,9 +1857,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1750,9 +1869,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1761,9 +1881,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1772,9 +1893,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1783,9 +1905,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1794,9 +1917,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1805,9 +1929,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1816,9 +1941,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1827,9 +1953,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1838,9 +1965,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1849,9 +1977,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1860,9 +1989,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1871,9 +2001,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1882,9 +2013,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1893,9 +2025,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1904,9 +2037,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1915,9 +2049,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1926,9 +2061,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1937,9 +2073,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1948,9 +2085,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {4}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1959,9 +2097,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1970,9 +2109,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1981,9 +2121,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1992,9 +2133,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2003,9 +2145,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2014,9 +2157,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2025,9 +2169,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2036,9 +2181,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2047,9 +2193,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2058,9 +2205,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2069,9 +2217,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2080,9 +2229,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2091,9 +2241,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2102,9 +2253,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2113,9 +2265,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2124,9 +2277,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2135,9 +2289,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2146,9 +2301,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2157,9 +2313,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2168,9 +2325,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2179,9 +2337,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2190,9 +2349,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2201,9 +2361,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {5}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2212,9 +2373,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2223,9 +2385,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2234,9 +2397,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2245,9 +2409,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2256,9 +2421,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2267,9 +2433,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2278,9 +2445,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2289,9 +2457,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2300,9 +2469,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2311,9 +2481,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2322,9 +2493,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2333,9 +2505,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2344,9 +2517,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2355,9 +2529,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2366,9 +2541,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2377,9 +2553,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2388,9 +2565,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2399,9 +2577,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2410,9 +2589,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2421,9 +2601,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2432,9 +2613,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2443,9 +2625,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2454,9 +2637,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {6}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2465,9 +2649,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2476,9 +2661,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2487,9 +2673,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2498,9 +2685,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2509,9 +2697,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2520,9 +2709,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2531,9 +2721,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2542,9 +2733,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2553,9 +2745,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2564,9 +2757,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2575,9 +2769,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2586,9 +2781,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2597,9 +2793,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2608,9 +2805,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2619,9 +2817,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2630,9 +2829,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2641,9 +2841,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2652,9 +2853,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2663,9 +2865,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2674,9 +2877,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2685,9 +2889,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2696,9 +2901,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2707,9 +2913,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {7}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2718,9 +2925,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2729,9 +2937,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2740,9 +2949,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2751,9 +2961,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2762,9 +2973,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2773,9 +2985,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2784,9 +2997,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2795,9 +3009,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2806,9 +3021,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2817,9 +3033,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2828,9 +3045,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2839,9 +3057,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2850,9 +3069,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2861,9 +3081,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2872,9 +3093,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2883,9 +3105,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2894,9 +3117,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2905,9 +3129,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2916,9 +3141,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2927,9 +3153,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2938,9 +3165,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2949,9 +3177,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2960,9 +3189,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {8}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2971,9 +3201,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2982,9 +3213,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2993,9 +3225,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3004,9 +3237,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3015,9 +3249,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3026,9 +3261,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3037,9 +3273,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3048,9 +3285,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3059,9 +3297,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3070,9 +3309,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3081,9 +3321,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3092,9 +3333,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3103,9 +3345,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3114,9 +3357,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3125,9 +3369,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3136,9 +3381,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3147,9 +3393,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3158,9 +3405,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3169,9 +3417,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3180,9 +3429,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3191,9 +3441,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3202,9 +3453,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3213,9 +3465,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {9}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -3224,9 +3477,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3235,9 +3489,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3246,9 +3501,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3257,9 +3513,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3268,9 +3525,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3279,9 +3537,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3290,9 +3549,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3301,9 +3561,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3312,9 +3573,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3323,9 +3585,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3334,9 +3597,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3345,9 +3609,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3356,9 +3621,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3367,9 +3633,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3378,9 +3645,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3389,9 +3657,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3400,9 +3669,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3411,9 +3681,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3422,9 +3693,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3433,9 +3705,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3444,9 +3717,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3455,9 +3729,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3466,9 +3741,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {10}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -3477,9 +3753,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3488,9 +3765,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3499,9 +3777,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3510,9 +3789,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3521,9 +3801,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3532,9 +3813,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3543,9 +3825,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3554,9 +3837,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3565,9 +3849,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3576,9 +3861,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3587,9 +3873,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3598,9 +3885,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3609,9 +3897,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3620,9 +3909,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3631,9 +3921,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3642,9 +3933,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3653,9 +3945,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3664,9 +3957,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3675,9 +3969,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3686,9 +3981,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3697,9 +3993,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3708,9 +4005,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3719,9 +4017,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {11}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -3730,9 +4029,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3741,9 +4041,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3752,9 +4053,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3763,9 +4065,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3774,9 +4077,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3785,9 +4089,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3796,9 +4101,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3807,9 +4113,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3818,9 +4125,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3829,9 +4137,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3840,9 +4149,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3851,9 +4161,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3862,9 +4173,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3873,9 +4185,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3884,9 +4197,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3895,9 +4209,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3906,9 +4221,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3917,9 +4233,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3928,9 +4245,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3939,9 +4257,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3950,9 +4269,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3961,9 +4281,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3972,9 +4293,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {12}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -3983,9 +4305,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3994,9 +4317,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4005,9 +4329,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4016,9 +4341,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4027,9 +4353,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4038,9 +4365,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4049,9 +4377,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4060,9 +4389,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4071,9 +4401,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4082,9 +4413,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4093,9 +4425,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4104,9 +4437,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4115,9 +4449,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4126,9 +4461,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4137,9 +4473,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4148,9 +4485,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4159,9 +4497,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4170,9 +4509,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4181,9 +4521,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4192,9 +4533,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4203,9 +4545,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4214,9 +4557,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4225,9 +4569,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {13}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -4236,9 +4581,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4247,9 +4593,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4258,9 +4605,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4269,9 +4617,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4280,9 +4629,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4291,9 +4641,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4302,9 +4653,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4313,9 +4665,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4324,9 +4677,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4335,9 +4689,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4346,9 +4701,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4357,9 +4713,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4368,9 +4725,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4379,9 +4737,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4390,9 +4749,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4401,9 +4761,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4412,9 +4773,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4423,9 +4785,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4434,9 +4797,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4445,9 +4809,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4456,9 +4821,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4467,9 +4833,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4478,9 +4845,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {14}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -4489,9 +4857,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4500,9 +4869,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4511,9 +4881,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4522,9 +4893,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4533,9 +4905,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4544,9 +4917,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4555,9 +4929,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4566,9 +4941,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4577,9 +4953,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4588,9 +4965,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4599,9 +4977,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4610,9 +4989,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4621,9 +5001,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4632,9 +5013,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4643,9 +5025,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4654,9 +5037,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4665,9 +5049,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4676,9 +5061,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4687,9 +5073,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4698,9 +5085,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4709,9 +5097,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4720,9 +5109,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4731,9 +5121,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {15}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -4742,9 +5133,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4753,9 +5145,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4764,9 +5157,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4775,9 +5169,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4786,9 +5181,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4797,9 +5193,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4808,9 +5205,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4819,9 +5217,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4830,9 +5229,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4841,9 +5241,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4852,9 +5253,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4863,9 +5265,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4874,9 +5277,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4885,9 +5289,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4896,9 +5301,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4907,9 +5313,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4918,9 +5325,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4929,9 +5337,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4940,9 +5349,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4951,9 +5361,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4962,9 +5373,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4973,9 +5385,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4984,9 +5397,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {16}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -4995,9 +5409,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5006,9 +5421,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5017,9 +5433,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5028,9 +5445,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5039,9 +5457,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5050,9 +5469,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5061,9 +5481,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5072,9 +5493,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5083,9 +5505,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5094,9 +5517,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5105,9 +5529,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5116,9 +5541,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5127,9 +5553,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5138,9 +5565,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5149,9 +5577,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5160,9 +5589,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5171,9 +5601,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5182,9 +5613,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5193,9 +5625,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5204,9 +5637,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5215,9 +5649,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5226,9 +5661,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5237,9 +5673,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {17}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -5248,9 +5685,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5259,9 +5697,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5270,9 +5709,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5281,9 +5721,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5292,9 +5733,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5303,9 +5745,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5314,9 +5757,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5325,9 +5769,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5336,9 +5781,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5347,9 +5793,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5358,9 +5805,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5369,9 +5817,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5380,9 +5829,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5391,9 +5841,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5402,9 +5853,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5413,9 +5865,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5424,9 +5877,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5435,9 +5889,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5446,9 +5901,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5457,9 +5913,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5468,9 +5925,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5479,9 +5937,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5490,9 +5949,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {18}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -5501,9 +5961,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5512,9 +5973,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5523,9 +5985,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5534,9 +5997,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5545,9 +6009,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5556,9 +6021,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5567,9 +6033,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5578,9 +6045,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5589,9 +6057,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5600,9 +6069,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5611,9 +6081,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5622,9 +6093,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5633,9 +6105,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5644,9 +6117,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5655,9 +6129,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5666,9 +6141,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5677,9 +6153,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5688,9 +6165,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5699,9 +6177,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5710,9 +6189,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5721,9 +6201,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5732,9 +6213,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5743,9 +6225,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {19}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -5754,9 +6237,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5765,9 +6249,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5776,9 +6261,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5787,9 +6273,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5798,9 +6285,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5809,9 +6297,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5820,9 +6309,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5831,9 +6321,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5842,9 +6333,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5853,9 +6345,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5864,9 +6357,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5875,9 +6369,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5886,9 +6381,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5897,9 +6393,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5908,9 +6405,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5919,9 +6417,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5930,9 +6429,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5941,9 +6441,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5952,9 +6453,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5963,9 +6465,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5974,9 +6477,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5985,9 +6489,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5996,9 +6501,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {20}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -6007,9 +6513,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -6018,9 +6525,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -6029,9 +6537,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -6040,9 +6549,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -6051,9 +6561,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -6062,9 +6573,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -6073,9 +6585,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -6084,9 +6597,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -6095,9 +6609,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -6106,9 +6621,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -6117,9 +6633,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -6128,9 +6645,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -6139,9 +6657,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -6150,9 +6669,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -6161,9 +6681,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -6172,9 +6693,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -6183,9 +6705,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -6194,9 +6717,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -6205,9 +6729,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -6216,9 +6741,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -6227,9 +6753,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -6238,9 +6765,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -6249,9 +6777,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {21}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -6260,9 +6789,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -6271,9 +6801,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -6282,9 +6813,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -6293,9 +6825,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -6304,9 +6837,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -6315,9 +6849,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -6326,9 +6861,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -6337,9 +6873,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -6348,9 +6885,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -6359,9 +6897,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -6370,9 +6909,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -6381,9 +6921,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -6392,9 +6933,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -6403,9 +6945,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -6414,9 +6957,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -6425,9 +6969,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -6436,9 +6981,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -6447,9 +6993,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -6458,9 +7005,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -6469,9 +7017,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -6480,9 +7029,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -6491,9 +7041,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -6502,18 +7053,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, {22}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {22}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -6522,9 +7075,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -6532,9 +7086,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -6545,9 +7100,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -504,216 +504,240 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {12})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {12}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {13})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {13}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {14})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {14}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {15})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {15}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {16})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {16}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {17})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {17}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {18})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {18}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T20))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {19})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T20)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {19}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T21))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {20})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T21)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {20}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T22))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {21})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T22)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {21}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T23))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {22})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T23)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {22}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T24))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, {23})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T24)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -722,9 +746,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -733,9 +758,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -744,9 +770,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -755,9 +782,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -766,9 +794,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -777,9 +806,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -788,9 +818,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -799,9 +830,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -810,9 +842,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -821,9 +854,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -832,9 +866,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -843,9 +878,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -854,9 +890,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -865,9 +902,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -876,9 +914,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -887,9 +926,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -898,9 +938,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -909,9 +950,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -920,9 +962,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -931,9 +974,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -942,9 +986,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -953,9 +998,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -964,9 +1010,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -975,9 +1022,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {0}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -986,9 +1034,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -997,9 +1046,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1008,9 +1058,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1019,9 +1070,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1030,9 +1082,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1041,9 +1094,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1052,9 +1106,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1063,9 +1118,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1074,9 +1130,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1085,9 +1142,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1096,9 +1154,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1107,9 +1166,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1118,9 +1178,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1129,9 +1190,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1140,9 +1202,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1151,9 +1214,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1162,9 +1226,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1173,9 +1238,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1184,9 +1250,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1195,9 +1262,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1206,9 +1274,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1217,9 +1286,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1228,9 +1298,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1239,9 +1310,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {1}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -1250,9 +1322,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1261,9 +1334,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1272,9 +1346,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1283,9 +1358,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1294,9 +1370,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1305,9 +1382,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1316,9 +1394,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1327,9 +1406,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1338,9 +1418,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1349,9 +1430,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1360,9 +1442,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1371,9 +1454,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1382,9 +1466,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1393,9 +1478,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1404,9 +1490,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1415,9 +1502,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1426,9 +1514,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1437,9 +1526,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1448,9 +1538,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1459,9 +1550,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1470,9 +1562,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1481,9 +1574,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1492,9 +1586,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1503,9 +1598,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {2}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -1514,9 +1610,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1525,9 +1622,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1536,9 +1634,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1547,9 +1646,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1558,9 +1658,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1569,9 +1670,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1580,9 +1682,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1591,9 +1694,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1602,9 +1706,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1613,9 +1718,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1624,9 +1730,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1635,9 +1742,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1646,9 +1754,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1657,9 +1766,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1668,9 +1778,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1679,9 +1790,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1690,9 +1802,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1701,9 +1814,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1712,9 +1826,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1723,9 +1838,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1734,9 +1850,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1745,9 +1862,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1756,9 +1874,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1767,9 +1886,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {3}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -1778,9 +1898,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1789,9 +1910,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1800,9 +1922,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1811,9 +1934,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1822,9 +1946,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1833,9 +1958,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1844,9 +1970,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1855,9 +1982,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1866,9 +1994,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1877,9 +2006,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1888,9 +2018,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1899,9 +2030,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1910,9 +2042,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1921,9 +2054,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1932,9 +2066,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1943,9 +2078,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1954,9 +2090,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1965,9 +2102,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1976,9 +2114,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1987,9 +2126,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1998,9 +2138,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2009,9 +2150,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2020,9 +2162,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2031,9 +2174,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {4}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -2042,9 +2186,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2053,9 +2198,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2064,9 +2210,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2075,9 +2222,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2086,9 +2234,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2097,9 +2246,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2108,9 +2258,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2119,9 +2270,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2130,9 +2282,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2141,9 +2294,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2152,9 +2306,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2163,9 +2318,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2174,9 +2330,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2185,9 +2342,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2196,9 +2354,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2207,9 +2366,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2218,9 +2378,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2229,9 +2390,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2240,9 +2402,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2251,9 +2414,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2262,9 +2426,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2273,9 +2438,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2284,9 +2450,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2295,9 +2462,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {5}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -2306,9 +2474,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2317,9 +2486,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2328,9 +2498,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2339,9 +2510,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2350,9 +2522,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2361,9 +2534,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2372,9 +2546,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2383,9 +2558,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2394,9 +2570,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2405,9 +2582,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2416,9 +2594,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2427,9 +2606,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2438,9 +2618,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2449,9 +2630,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2460,9 +2642,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2471,9 +2654,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2482,9 +2666,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2493,9 +2678,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2504,9 +2690,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2515,9 +2702,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2526,9 +2714,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2537,9 +2726,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2548,9 +2738,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2559,9 +2750,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {6}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -2570,9 +2762,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2581,9 +2774,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2592,9 +2786,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2603,9 +2798,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2614,9 +2810,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2625,9 +2822,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2636,9 +2834,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2647,9 +2846,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2658,9 +2858,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2669,9 +2870,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2680,9 +2882,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2691,9 +2894,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2702,9 +2906,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2713,9 +2918,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2724,9 +2930,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2735,9 +2942,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2746,9 +2954,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2757,9 +2966,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2768,9 +2978,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2779,9 +2990,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2790,9 +3002,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2801,9 +3014,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2812,9 +3026,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2823,9 +3038,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {7}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -2834,9 +3050,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2845,9 +3062,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2856,9 +3074,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2867,9 +3086,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2878,9 +3098,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2889,9 +3110,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2900,9 +3122,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2911,9 +3134,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2922,9 +3146,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2933,9 +3158,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2944,9 +3170,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2955,9 +3182,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2966,9 +3194,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2977,9 +3206,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2988,9 +3218,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2999,9 +3230,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3010,9 +3242,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3021,9 +3254,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3032,9 +3266,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3043,9 +3278,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3054,9 +3290,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3065,9 +3302,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3076,9 +3314,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -3087,9 +3326,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {8}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -3098,9 +3338,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3109,9 +3350,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3120,9 +3362,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3131,9 +3374,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3142,9 +3386,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3153,9 +3398,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3164,9 +3410,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3175,9 +3422,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3186,9 +3434,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3197,9 +3446,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3208,9 +3458,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3219,9 +3470,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3230,9 +3482,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3241,9 +3494,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3252,9 +3506,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3263,9 +3518,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3274,9 +3530,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3285,9 +3542,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3296,9 +3554,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3307,9 +3566,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3318,9 +3578,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3329,9 +3590,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3340,9 +3602,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -3351,9 +3614,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {9}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -3362,9 +3626,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3373,9 +3638,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3384,9 +3650,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3395,9 +3662,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3406,9 +3674,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3417,9 +3686,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3428,9 +3698,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3439,9 +3710,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3450,9 +3722,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3461,9 +3734,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3472,9 +3746,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3483,9 +3758,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3494,9 +3770,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3505,9 +3782,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3516,9 +3794,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3527,9 +3806,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3538,9 +3818,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3549,9 +3830,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3560,9 +3842,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3571,9 +3854,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3582,9 +3866,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3593,9 +3878,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3604,9 +3890,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -3615,9 +3902,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {10}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -3626,9 +3914,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3637,9 +3926,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3648,9 +3938,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3659,9 +3950,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3670,9 +3962,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3681,9 +3974,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3692,9 +3986,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3703,9 +3998,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3714,9 +4010,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3725,9 +4022,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3736,9 +4034,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3747,9 +4046,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3758,9 +4058,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3769,9 +4070,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3780,9 +4082,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3791,9 +4094,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3802,9 +4106,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3813,9 +4118,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3824,9 +4130,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3835,9 +4142,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3846,9 +4154,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3857,9 +4166,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3868,9 +4178,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -3879,9 +4190,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {11}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -3890,9 +4202,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3901,9 +4214,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3912,9 +4226,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3923,9 +4238,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3934,9 +4250,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3945,9 +4262,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3956,9 +4274,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3967,9 +4286,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3978,9 +4298,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3989,9 +4310,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4000,9 +4322,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4011,9 +4334,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4022,9 +4346,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4033,9 +4358,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4044,9 +4370,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4055,9 +4382,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4066,9 +4394,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4077,9 +4406,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4088,9 +4418,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4099,9 +4430,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4110,9 +4442,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4121,9 +4454,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4132,9 +4466,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -4143,9 +4478,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {12}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -4154,9 +4490,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4165,9 +4502,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4176,9 +4514,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4187,9 +4526,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4198,9 +4538,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4209,9 +4550,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4220,9 +4562,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4231,9 +4574,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4242,9 +4586,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4253,9 +4598,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4264,9 +4610,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4275,9 +4622,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4286,9 +4634,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4297,9 +4646,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4308,9 +4658,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4319,9 +4670,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4330,9 +4682,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4341,9 +4694,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4352,9 +4706,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4363,9 +4718,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4374,9 +4730,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4385,9 +4742,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4396,9 +4754,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -4407,9 +4766,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {13}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -4418,9 +4778,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4429,9 +4790,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4440,9 +4802,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4451,9 +4814,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4462,9 +4826,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4473,9 +4838,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4484,9 +4850,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4495,9 +4862,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4506,9 +4874,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4517,9 +4886,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4528,9 +4898,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4539,9 +4910,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4550,9 +4922,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4561,9 +4934,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4572,9 +4946,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4583,9 +4958,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4594,9 +4970,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4605,9 +4982,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4616,9 +4994,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4627,9 +5006,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4638,9 +5018,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4649,9 +5030,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4660,9 +5042,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -4671,9 +5054,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {14}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -4682,9 +5066,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4693,9 +5078,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4704,9 +5090,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4715,9 +5102,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4726,9 +5114,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4737,9 +5126,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4748,9 +5138,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4759,9 +5150,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4770,9 +5162,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4781,9 +5174,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4792,9 +5186,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4803,9 +5198,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4814,9 +5210,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4825,9 +5222,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4836,9 +5234,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4847,9 +5246,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4858,9 +5258,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4869,9 +5270,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4880,9 +5282,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4891,9 +5294,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4902,9 +5306,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4913,9 +5318,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4924,9 +5330,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -4935,9 +5342,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {15}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -4946,9 +5354,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4957,9 +5366,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4968,9 +5378,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4979,9 +5390,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4990,9 +5402,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5001,9 +5414,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5012,9 +5426,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5023,9 +5438,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5034,9 +5450,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5045,9 +5462,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5056,9 +5474,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5067,9 +5486,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5078,9 +5498,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5089,9 +5510,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5100,9 +5522,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5111,9 +5534,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5122,9 +5546,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5133,9 +5558,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5144,9 +5570,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5155,9 +5582,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5166,9 +5594,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5177,9 +5606,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5188,9 +5618,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -5199,9 +5630,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {16}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -5210,9 +5642,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5221,9 +5654,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5232,9 +5666,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5243,9 +5678,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5254,9 +5690,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5265,9 +5702,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5276,9 +5714,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5287,9 +5726,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5298,9 +5738,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5309,9 +5750,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5320,9 +5762,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5331,9 +5774,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5342,9 +5786,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5353,9 +5798,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5364,9 +5810,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5375,9 +5822,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5386,9 +5834,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5397,9 +5846,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5408,9 +5858,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5419,9 +5870,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5430,9 +5882,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5441,9 +5894,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5452,9 +5906,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -5463,9 +5918,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {17}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -5474,9 +5930,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5485,9 +5942,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5496,9 +5954,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5507,9 +5966,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5518,9 +5978,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5529,9 +5990,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5540,9 +6002,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5551,9 +6014,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5562,9 +6026,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5573,9 +6038,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5584,9 +6050,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5595,9 +6062,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5606,9 +6074,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5617,9 +6086,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5628,9 +6098,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5639,9 +6110,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5650,9 +6122,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5661,9 +6134,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5672,9 +6146,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5683,9 +6158,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5694,9 +6170,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5705,9 +6182,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5716,9 +6194,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -5727,9 +6206,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {18}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -5738,9 +6218,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5749,9 +6230,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5760,9 +6242,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5771,9 +6254,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5782,9 +6266,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5793,9 +6278,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5804,9 +6290,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5815,9 +6302,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5826,9 +6314,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5837,9 +6326,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5848,9 +6338,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5859,9 +6350,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5870,9 +6362,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5881,9 +6374,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5892,9 +6386,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5903,9 +6398,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5914,9 +6410,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5925,9 +6422,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5936,9 +6434,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5947,9 +6446,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5958,9 +6458,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5969,9 +6470,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5980,9 +6482,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -5991,9 +6494,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {19}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -6002,9 +6506,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -6013,9 +6518,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -6024,9 +6530,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -6035,9 +6542,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -6046,9 +6554,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -6057,9 +6566,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -6068,9 +6578,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -6079,9 +6590,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -6090,9 +6602,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -6101,9 +6614,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -6112,9 +6626,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -6123,9 +6638,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -6134,9 +6650,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -6145,9 +6662,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -6156,9 +6674,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -6167,9 +6686,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -6178,9 +6698,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -6189,9 +6710,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -6200,9 +6722,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -6211,9 +6734,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -6222,9 +6746,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -6233,9 +6758,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -6244,9 +6770,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -6255,9 +6782,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {20}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -6266,9 +6794,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -6277,9 +6806,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -6288,9 +6818,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -6299,9 +6830,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -6310,9 +6842,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -6321,9 +6854,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -6332,9 +6866,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -6343,9 +6878,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -6354,9 +6890,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -6365,9 +6902,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -6376,9 +6914,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -6387,9 +6926,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -6398,9 +6938,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -6409,9 +6950,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -6420,9 +6962,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -6431,9 +6974,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -6442,9 +6986,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -6453,9 +6998,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -6464,9 +7010,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -6475,9 +7022,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -6486,9 +7034,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -6497,9 +7046,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -6508,9 +7058,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -6519,9 +7070,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {21}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -6530,9 +7082,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -6541,9 +7094,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -6552,9 +7106,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -6563,9 +7118,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -6574,9 +7130,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -6585,9 +7142,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -6596,9 +7154,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -6607,9 +7166,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -6618,9 +7178,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -6629,9 +7190,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -6640,9 +7202,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -6651,9 +7214,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -6662,9 +7226,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -6673,9 +7238,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -6684,9 +7250,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -6695,9 +7262,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -6706,9 +7274,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -6717,9 +7286,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -6728,9 +7298,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -6739,9 +7310,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -6750,9 +7322,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -6761,9 +7334,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -6772,9 +7346,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -6783,9 +7358,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {22}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -6794,9 +7370,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -6805,9 +7382,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -6816,9 +7394,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -6827,9 +7406,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -6838,9 +7418,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -6849,9 +7430,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -6860,9 +7442,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -6871,9 +7454,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -6882,9 +7466,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -6893,9 +7478,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -6904,9 +7490,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -6915,9 +7502,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -6926,9 +7514,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -6937,9 +7526,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -6948,9 +7538,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -6959,9 +7550,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -6970,9 +7562,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -6981,9 +7574,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -6992,9 +7586,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -7003,9 +7598,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -7014,9 +7610,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -7025,9 +7622,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -7036,9 +7634,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -7047,18 +7646,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, {23}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {23}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -7067,9 +7668,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -7077,9 +7679,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -7090,9 +7693,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -523,225 +523,250 @@ Namespace Expressions
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {0})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T1)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {0}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {1})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T2)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {1}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {2})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T3)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {2}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {3})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T4)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {3}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {4})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T5)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {4}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {5})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T6)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {5}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {6})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T7)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {6}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {7})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T8)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {7}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {8})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T9)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {8}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {9})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T10)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {9}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {10})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T11)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {10}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {11})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T12)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {11}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {12})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T13)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {12}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {13})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T14)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {13}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {14})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T15)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {14}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {15})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T16)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {15}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {16})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T17)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {16}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {17})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T18)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {17}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {18})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T19)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {18}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T20))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {19})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T20)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {19}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T21))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {20})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T21)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {20}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T22))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {21})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T22)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {21}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T23))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {22})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T23)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {22}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T24))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {23})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T24)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {23}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T25))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, {24})
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of T25)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -750,9 +775,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -761,9 +787,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -772,9 +799,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -783,9 +811,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -794,9 +823,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -805,9 +835,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -816,9 +847,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -827,9 +859,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -838,9 +871,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -849,9 +883,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -860,9 +895,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -871,9 +907,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -882,9 +919,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -893,9 +931,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -904,9 +943,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -915,9 +955,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -926,9 +967,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -937,9 +979,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -948,9 +991,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -959,9 +1003,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -970,9 +1015,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -981,9 +1027,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -992,9 +1039,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1003,9 +1051,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -1014,9 +1063,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {0}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T1, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -1025,9 +1075,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1036,9 +1087,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1047,9 +1099,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1058,9 +1111,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1069,9 +1123,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1080,9 +1135,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1091,9 +1147,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1102,9 +1159,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1113,9 +1171,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1124,9 +1183,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1135,9 +1195,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1146,9 +1207,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1157,9 +1219,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1168,9 +1231,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1179,9 +1243,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1190,9 +1255,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1201,9 +1267,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1212,9 +1279,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1223,9 +1291,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1234,9 +1303,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1245,9 +1315,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1256,9 +1327,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1267,9 +1339,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1278,9 +1351,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -1289,9 +1363,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {1}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T2, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -1300,9 +1375,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1311,9 +1387,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1322,9 +1399,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1333,9 +1411,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1344,9 +1423,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1355,9 +1435,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1366,9 +1447,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1377,9 +1459,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1388,9 +1471,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1399,9 +1483,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1410,9 +1495,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1421,9 +1507,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1432,9 +1519,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1443,9 +1531,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1454,9 +1543,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1465,9 +1555,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1476,9 +1567,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1487,9 +1579,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1498,9 +1591,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1509,9 +1603,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1520,9 +1615,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1531,9 +1627,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1542,9 +1639,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1553,9 +1651,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -1564,9 +1663,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {2}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T3, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -1575,9 +1675,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1586,9 +1687,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1597,9 +1699,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1608,9 +1711,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1619,9 +1723,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1630,9 +1735,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1641,9 +1747,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1652,9 +1759,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1663,9 +1771,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1674,9 +1783,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1685,9 +1795,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1696,9 +1807,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1707,9 +1819,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1718,9 +1831,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -1729,9 +1843,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -1740,9 +1855,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -1751,9 +1867,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -1762,9 +1879,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -1773,9 +1891,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -1784,9 +1903,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -1795,9 +1915,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -1806,9 +1927,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -1817,9 +1939,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -1828,9 +1951,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -1839,9 +1963,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {3}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T4, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -1850,9 +1975,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -1861,9 +1987,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -1872,9 +1999,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -1883,9 +2011,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -1894,9 +2023,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -1905,9 +2035,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -1916,9 +2047,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -1927,9 +2059,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -1938,9 +2071,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -1949,9 +2083,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -1960,9 +2095,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -1971,9 +2107,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -1982,9 +2119,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -1993,9 +2131,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2004,9 +2143,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2015,9 +2155,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2026,9 +2167,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2037,9 +2179,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2048,9 +2191,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2059,9 +2203,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2070,9 +2215,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2081,9 +2227,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2092,9 +2239,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2103,9 +2251,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -2114,9 +2263,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {4}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T5, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -2125,9 +2275,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2136,9 +2287,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2147,9 +2299,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2158,9 +2311,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2169,9 +2323,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2180,9 +2335,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2191,9 +2347,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2202,9 +2359,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2213,9 +2371,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2224,9 +2383,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2235,9 +2395,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2246,9 +2407,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2257,9 +2419,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2268,9 +2431,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2279,9 +2443,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2290,9 +2455,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2301,9 +2467,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2312,9 +2479,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2323,9 +2491,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2334,9 +2503,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2345,9 +2515,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2356,9 +2527,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2367,9 +2539,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2378,9 +2551,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -2389,9 +2563,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {5}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T6, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -2400,9 +2575,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2411,9 +2587,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2422,9 +2599,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2433,9 +2611,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2444,9 +2623,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2455,9 +2635,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2466,9 +2647,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2477,9 +2659,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2488,9 +2671,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2499,9 +2683,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2510,9 +2695,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2521,9 +2707,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2532,9 +2719,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2543,9 +2731,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2554,9 +2743,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2565,9 +2755,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2576,9 +2767,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2587,9 +2779,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2598,9 +2791,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2609,9 +2803,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2620,9 +2815,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2631,9 +2827,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2642,9 +2839,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2653,9 +2851,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -2664,9 +2863,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {6}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T7, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -2675,9 +2875,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2686,9 +2887,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2697,9 +2899,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2708,9 +2911,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2719,9 +2923,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -2730,9 +2935,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -2741,9 +2947,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -2752,9 +2959,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -2763,9 +2971,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -2774,9 +2983,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -2785,9 +2995,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -2796,9 +3007,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -2807,9 +3019,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -2818,9 +3031,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -2829,9 +3043,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -2840,9 +3055,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -2851,9 +3067,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -2862,9 +3079,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -2873,9 +3091,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -2884,9 +3103,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -2895,9 +3115,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -2906,9 +3127,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -2917,9 +3139,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -2928,9 +3151,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -2939,9 +3163,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {7}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T8, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -2950,9 +3175,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -2961,9 +3187,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -2972,9 +3199,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -2983,9 +3211,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -2994,9 +3223,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3005,9 +3235,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3016,9 +3247,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3027,9 +3259,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3038,9 +3271,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3049,9 +3283,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3060,9 +3295,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3071,9 +3307,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3082,9 +3319,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3093,9 +3331,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3104,9 +3343,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3115,9 +3355,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3126,9 +3367,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3137,9 +3379,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3148,9 +3391,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3159,9 +3403,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3170,9 +3415,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3181,9 +3427,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3192,9 +3439,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -3203,9 +3451,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -3214,9 +3463,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {8}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T9, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -3225,9 +3475,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3236,9 +3487,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3247,9 +3499,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3258,9 +3511,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3269,9 +3523,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3280,9 +3535,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3291,9 +3547,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3302,9 +3559,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3313,9 +3571,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3324,9 +3583,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3335,9 +3595,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3346,9 +3607,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3357,9 +3619,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3368,9 +3631,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3379,9 +3643,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3390,9 +3655,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3401,9 +3667,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3412,9 +3679,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3423,9 +3691,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3434,9 +3703,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3445,9 +3715,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3456,9 +3727,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3467,9 +3739,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -3478,9 +3751,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -3489,9 +3763,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {9}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T10, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -3500,9 +3775,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3511,9 +3787,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3522,9 +3799,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3533,9 +3811,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3544,9 +3823,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3555,9 +3835,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3566,9 +3847,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3577,9 +3859,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3588,9 +3871,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3599,9 +3883,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3610,9 +3895,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3621,9 +3907,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3632,9 +3919,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3643,9 +3931,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3654,9 +3943,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3665,9 +3955,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3676,9 +3967,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3687,9 +3979,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3698,9 +3991,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3709,9 +4003,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3720,9 +4015,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -3731,9 +4027,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -3742,9 +4039,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -3753,9 +4051,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -3764,9 +4063,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {10}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T11, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -3775,9 +4075,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -3786,9 +4087,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -3797,9 +4099,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -3808,9 +4111,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -3819,9 +4123,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -3830,9 +4135,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -3841,9 +4147,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -3852,9 +4159,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -3863,9 +4171,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -3874,9 +4183,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -3885,9 +4195,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -3896,9 +4207,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -3907,9 +4219,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -3918,9 +4231,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -3929,9 +4243,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -3940,9 +4255,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -3951,9 +4267,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -3962,9 +4279,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -3973,9 +4291,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -3984,9 +4303,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -3995,9 +4315,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4006,9 +4327,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4017,9 +4339,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -4028,9 +4351,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -4039,9 +4363,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {11}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T12, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -4050,9 +4375,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4061,9 +4387,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4072,9 +4399,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4083,9 +4411,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4094,9 +4423,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4105,9 +4435,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4116,9 +4447,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4127,9 +4459,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4138,9 +4471,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4149,9 +4483,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4160,9 +4495,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4171,9 +4507,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4182,9 +4519,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4193,9 +4531,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4204,9 +4543,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4215,9 +4555,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4226,9 +4567,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4237,9 +4579,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4248,9 +4591,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4259,9 +4603,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4270,9 +4615,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4281,9 +4627,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4292,9 +4639,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -4303,9 +4651,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -4314,9 +4663,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {12}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T13, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -4325,9 +4675,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4336,9 +4687,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4347,9 +4699,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4358,9 +4711,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4369,9 +4723,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4380,9 +4735,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4391,9 +4747,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4402,9 +4759,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4413,9 +4771,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4424,9 +4783,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4435,9 +4795,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4446,9 +4807,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4457,9 +4819,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4468,9 +4831,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4479,9 +4843,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4490,9 +4855,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4501,9 +4867,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4512,9 +4879,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4523,9 +4891,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4534,9 +4903,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4545,9 +4915,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4556,9 +4927,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4567,9 +4939,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -4578,9 +4951,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -4589,9 +4963,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {13}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T14, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -4600,9 +4975,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4611,9 +4987,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4622,9 +4999,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4633,9 +5011,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4644,9 +5023,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4655,9 +5035,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4666,9 +5047,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4677,9 +5059,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4688,9 +5071,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4699,9 +5083,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4710,9 +5095,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4721,9 +5107,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -4732,9 +5119,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -4743,9 +5131,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -4754,9 +5143,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -4765,9 +5155,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -4776,9 +5167,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -4787,9 +5179,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -4798,9 +5191,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -4809,9 +5203,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -4820,9 +5215,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -4831,9 +5227,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -4842,9 +5239,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -4853,9 +5251,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -4864,9 +5263,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {14}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T15, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -4875,9 +5275,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -4886,9 +5287,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -4897,9 +5299,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -4908,9 +5311,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -4919,9 +5323,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -4930,9 +5335,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -4941,9 +5347,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -4952,9 +5359,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -4963,9 +5371,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -4974,9 +5383,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -4985,9 +5395,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -4996,9 +5407,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5007,9 +5419,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5018,9 +5431,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5029,9 +5443,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5040,9 +5455,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5051,9 +5467,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5062,9 +5479,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5073,9 +5491,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5084,9 +5503,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5095,9 +5515,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5106,9 +5527,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5117,9 +5539,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -5128,9 +5551,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -5139,9 +5563,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {15}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T16, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -5150,9 +5575,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5161,9 +5587,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5172,9 +5599,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5183,9 +5611,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5194,9 +5623,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5205,9 +5635,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5216,9 +5647,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5227,9 +5659,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5238,9 +5671,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5249,9 +5683,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5260,9 +5695,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5271,9 +5707,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5282,9 +5719,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5293,9 +5731,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5304,9 +5743,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5315,9 +5755,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5326,9 +5767,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5337,9 +5779,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5348,9 +5791,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5359,9 +5803,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5370,9 +5815,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5381,9 +5827,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5392,9 +5839,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -5403,9 +5851,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -5414,9 +5863,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {16}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T17, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -5425,9 +5875,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5436,9 +5887,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5447,9 +5899,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5458,9 +5911,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5469,9 +5923,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5480,9 +5935,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5491,9 +5947,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5502,9 +5959,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5513,9 +5971,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5524,9 +5983,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5535,9 +5995,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5546,9 +6007,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5557,9 +6019,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5568,9 +6031,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5579,9 +6043,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5590,9 +6055,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5601,9 +6067,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5612,9 +6079,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5623,9 +6091,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5634,9 +6103,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5645,9 +6115,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5656,9 +6127,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5667,9 +6139,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -5678,9 +6151,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -5689,9 +6163,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {17}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T18, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -5700,9 +6175,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5711,9 +6187,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5722,9 +6199,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -5733,9 +6211,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -5744,9 +6223,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -5755,9 +6235,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -5766,9 +6247,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -5777,9 +6259,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -5788,9 +6271,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -5799,9 +6283,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -5810,9 +6295,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -5821,9 +6307,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -5832,9 +6319,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -5843,9 +6331,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -5854,9 +6343,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -5865,9 +6355,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -5876,9 +6367,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -5887,9 +6379,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -5898,9 +6391,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -5909,9 +6403,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -5920,9 +6415,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -5931,9 +6427,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -5942,9 +6439,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -5953,9 +6451,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -5964,9 +6463,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {18}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T19, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -5975,9 +6475,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -5986,9 +6487,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -5997,9 +6499,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -6008,9 +6511,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -6019,9 +6523,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -6030,9 +6535,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -6041,9 +6547,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -6052,9 +6559,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -6063,9 +6571,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -6074,9 +6583,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -6085,9 +6595,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -6096,9 +6607,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -6107,9 +6619,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -6118,9 +6631,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -6129,9 +6643,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -6140,9 +6655,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -6151,9 +6667,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -6162,9 +6679,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -6173,9 +6691,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -6184,9 +6703,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -6195,9 +6715,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -6206,9 +6727,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -6217,9 +6739,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -6228,9 +6751,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -6239,9 +6763,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {19}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T20, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -6250,9 +6775,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -6261,9 +6787,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -6272,9 +6799,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -6283,9 +6811,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -6294,9 +6823,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -6305,9 +6835,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -6316,9 +6847,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -6327,9 +6859,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -6338,9 +6871,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -6349,9 +6883,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -6360,9 +6895,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -6371,9 +6907,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -6382,9 +6919,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -6393,9 +6931,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -6404,9 +6943,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -6415,9 +6955,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -6426,9 +6967,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -6437,9 +6979,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -6448,9 +6991,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -6459,9 +7003,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -6470,9 +7015,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -6481,9 +7027,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -6492,9 +7039,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -6503,9 +7051,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -6514,9 +7063,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {20}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T21, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -6525,9 +7075,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -6536,9 +7087,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -6547,9 +7099,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -6558,9 +7111,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -6569,9 +7123,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -6580,9 +7135,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -6591,9 +7147,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -6602,9 +7159,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -6613,9 +7171,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -6624,9 +7183,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -6635,9 +7195,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -6646,9 +7207,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -6657,9 +7219,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -6668,9 +7231,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -6679,9 +7243,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -6690,9 +7255,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -6701,9 +7267,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -6712,9 +7279,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -6723,9 +7291,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -6734,9 +7303,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -6745,9 +7315,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -6756,9 +7327,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -6767,9 +7339,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -6778,9 +7351,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -6789,9 +7363,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {21}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T22, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -6800,9 +7375,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -6811,9 +7387,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -6822,9 +7399,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -6833,9 +7411,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -6844,9 +7423,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -6855,9 +7435,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -6866,9 +7447,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -6877,9 +7459,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -6888,9 +7471,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -6899,9 +7483,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -6910,9 +7495,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -6921,9 +7507,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -6932,9 +7519,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -6943,9 +7531,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -6954,9 +7543,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -6965,9 +7555,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -6976,9 +7567,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -6987,9 +7579,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -6998,9 +7591,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -7009,9 +7603,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -7020,9 +7615,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -7031,9 +7627,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -7042,9 +7639,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -7053,9 +7651,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -7064,9 +7663,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {22}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T23, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -7075,9 +7675,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -7086,9 +7687,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -7097,9 +7699,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -7108,9 +7711,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -7119,9 +7723,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -7130,9 +7735,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -7141,9 +7747,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -7152,9 +7759,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -7163,9 +7771,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -7174,9 +7783,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -7185,9 +7795,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -7196,9 +7807,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -7207,9 +7819,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -7218,9 +7831,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -7229,9 +7843,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -7240,9 +7855,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -7251,9 +7867,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -7262,9 +7879,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -7273,9 +7891,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -7284,9 +7903,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -7295,9 +7915,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -7306,9 +7927,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -7317,9 +7939,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -7328,9 +7951,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -7339,9 +7963,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {23}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T24, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {24}, behavior)
     End Function
 
     ''' <summary>
@@ -7350,9 +7975,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {0})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T1, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -7361,9 +7987,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {1})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T2, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {1}, behavior)
     End Function
 
     ''' <summary>
@@ -7372,9 +7999,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {2})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T3, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {2}, behavior)
     End Function
 
     ''' <summary>
@@ -7383,9 +8011,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {3})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T4, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {3}, behavior)
     End Function
 
     ''' <summary>
@@ -7394,9 +8023,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {4})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T5, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {4}, behavior)
     End Function
 
     ''' <summary>
@@ -7405,9 +8035,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {5})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T6, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {5}, behavior)
     End Function
 
     ''' <summary>
@@ -7416,9 +8047,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {6})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T7, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {6}, behavior)
     End Function
 
     ''' <summary>
@@ -7427,9 +8059,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {7})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T8, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {7}, behavior)
     End Function
 
     ''' <summary>
@@ -7438,9 +8071,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {8})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T9, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {8}, behavior)
     End Function
 
     ''' <summary>
@@ -7449,9 +8083,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {9})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T10, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {9}, behavior)
     End Function
 
     ''' <summary>
@@ -7460,9 +8095,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {10})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T11, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {10}, behavior)
     End Function
 
     ''' <summary>
@@ -7471,9 +8107,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {11})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T12, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {11}, behavior)
     End Function
 
     ''' <summary>
@@ -7482,9 +8119,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {12})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T13, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {12}, behavior)
     End Function
 
     ''' <summary>
@@ -7493,9 +8131,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {13})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T14, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {13}, behavior)
     End Function
 
     ''' <summary>
@@ -7504,9 +8143,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {14})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T15, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {14}, behavior)
     End Function
 
     ''' <summary>
@@ -7515,9 +8155,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {15})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T16, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {15}, behavior)
     End Function
 
     ''' <summary>
@@ -7526,9 +8167,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {16})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T17, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {16}, behavior)
     End Function
 
     ''' <summary>
@@ -7537,9 +8179,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {17})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T18, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {17}, behavior)
     End Function
 
     ''' <summary>
@@ -7548,9 +8191,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {18})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T19, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {18}, behavior)
     End Function
 
     ''' <summary>
@@ -7559,9 +8203,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {19})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T20, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {19}, behavior)
     End Function
 
     ''' <summary>
@@ -7570,9 +8215,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {20})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T21, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {20}, behavior)
     End Function
 
     ''' <summary>
@@ -7581,9 +8227,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {21})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T22, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {21}, behavior)
     End Function
 
     ''' <summary>
@@ -7592,9 +8239,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {22})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T23, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {22}, behavior)
     End Function
 
     ''' <summary>
@@ -7603,9 +8251,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {23})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T24, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {23}, behavior)
     End Function
 
     ''' <summary>
@@ -7614,18 +8263,20 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, {24}, {24})
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of T25, TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of T25, TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {24}, behavior)
     End Function
 
     ''' <summary>
     ''' Includes &lt;column(s)&gt; to SELECT clause.
     ''' </summary>
     ''' <param name="action"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(action, Nothing)
+    Public Function Include(<DisallowNull> action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25))), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -7634,9 +8285,10 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="valueSelector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing)
+    Public Function Include(Of TProperty)(<DisallowNull> keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TProperty)), <DisallowNull> valueSelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TProperty)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, Nothing, Nothing, behavior)
     End Function
 
     ''' <summary>
@@ -7644,9 +8296,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(action As Expression, entityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Me.Builder.IncludeToSelected(action, entityIndexHints)
+    Private Function InternalInclude(action As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.IncludeToSelected(action, entityIndexHints, behavior)
       Return Me
     End Function
 
@@ -7657,9 +8310,10 @@ Namespace Expressions
     ''' <param name="valueSelector"></param>
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32()) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints)
+    Private Function InternalInclude(keySelector As Expression, valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.IncludeToSelected(keySelector, valueSelector, keySelectorEntityIndexHints, valueSelectorEntityIndexHints, behavior)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/WithHintsSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/WithHintsSelectSqlExpression.vb
@@ -56,10 +56,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -117,10 +116,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -178,10 +176,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -239,10 +236,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
-      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory)
     End Function
 
     ''' <summary>
@@ -280,10 +276,9 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinedSelectSqlExpression(Of T, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory)
       Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
       Return New JoinedSelectSqlExpression(Of T, TJoined)(Me.Builder, Me.Executor)
     End Function
@@ -343,10 +338,9 @@ Namespace Expressions
     ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSourceFactory"></param>
-    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T, TJoined)
-      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined))) As JoinSelectSqlExpression(Of T, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory)
       Return New JoinSelectSqlExpression(Of T, TJoined)(Me.Builder, Me.Executor)
     End Function
 
@@ -571,9 +565,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult))) As CustomSelectSqlExpression(Of TResult)
-      Return InternalSelect(Of TResult)(selector, {0})
+    Public Function [Select](Of TResult)(<DisallowNull> selector As Expression(Of Func(Of T, TResult)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0}, behavior)
     End Function
 
     ''' <summary>
@@ -582,9 +577,10 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
-      Me.Builder.AddSelect(selector, entityIndexHints)
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32(), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints, behavior)
       Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Internal/Query/AdHocTypeSqlResultReaderData.vb
+++ b/Source/Source/Yamo/Internal/Query/AdHocTypeSqlResultReaderData.vb
@@ -33,7 +33,7 @@ Namespace Internal.Query
     ''' <param name="ctorArguments"></param>
     ''' <param name="memberInits"></param>
     Public Sub New(<DisallowNull> sqlResult As AdHocTypeSqlResult, readerIndex As Int32, <DisallowNull> ctorArguments As ReaderDataBase(), <DisallowNull> memberInits As ReaderDataBase())
-      MyBase.New(sqlResult, readerIndex)
+      MyBase.New(sqlResult, readerIndex, Not sqlResult.CreationBehavior = NonModelEntityCreationBehavior.AlwaysCreateInstance)
       Me.CtorArguments = ctorArguments
       Me.MemberInits = memberInits
     End Sub

--- a/Source/Source/Yamo/Internal/Query/AnonymousTypeSqlResultReaderData.vb
+++ b/Source/Source/Yamo/Internal/Query/AnonymousTypeSqlResultReaderData.vb
@@ -25,7 +25,7 @@ Namespace Internal.Query
     ''' <param name="readerIndex"></param>
     ''' <param name="items"></param>
     Public Sub New(<DisallowNull> sqlResult As AnonymousTypeSqlResult, readerIndex As Int32, <DisallowNull> items As ReaderDataBase())
-      MyBase.New(sqlResult, readerIndex)
+      MyBase.New(sqlResult, readerIndex, Not sqlResult.CreationBehavior = NonModelEntityCreationBehavior.AlwaysCreateInstance)
       Me.Items = items
     End Sub
 

--- a/Source/Source/Yamo/Internal/Query/EntitySqlResultReaderData.vb
+++ b/Source/Source/Yamo/Internal/Query/EntitySqlResultReaderData.vb
@@ -55,7 +55,7 @@ Namespace Internal.Query
     ''' <param name="readerIndex"></param>
     ''' <param name="entityReader"></param>
     Public Sub New(<DisallowNull> sqlResult As EntitySqlResult, readerIndex As Int32, <DisallowNull> entityReader As Func(Of DbDataReader, Int32, Boolean(), Object))
-      MyBase.New(sqlResult, readerIndex)
+      MyBase.New(sqlResult, readerIndex, False)
       Me.Entity = sqlResult.Entity
       Me.Reader = entityReader
       Me.ContainsPKReader = Nothing
@@ -73,7 +73,7 @@ Namespace Internal.Query
     ''' <param name="containsPKReader"></param>
     ''' <param name="pkOffsets"></param>
     Public Sub New(<DisallowNull> sqlResult As EntitySqlResult, readerIndex As Int32, <DisallowNull> entityReader As Func(Of DbDataReader, Int32, Boolean(), Object), containsPKReader As Func(Of DbDataReader, Int32, Int32(), Boolean), pkOffsets As Int32())
-      MyBase.New(sqlResult, readerIndex)
+      MyBase.New(sqlResult, readerIndex, False)
       Me.Entity = sqlResult.Entity
       Me.Reader = entityReader
       Me.ContainsPKReader = containsPKReader
@@ -92,7 +92,7 @@ Namespace Internal.Query
     ''' <param name="pkOffsets"></param>
     ''' <param name="pkReader"></param>
     Public Sub New(<DisallowNull> sqlResult As EntitySqlResult, readerIndex As Int32, <DisallowNull> entityReader As Func(Of DbDataReader, Int32, Boolean(), Object), containsPKReader As Func(Of DbDataReader, Int32, Int32(), Boolean), pkOffsets As Int32(), pkReader As Func(Of DbDataReader, Int32, Int32(), Object))
-      MyBase.New(sqlResult, readerIndex)
+      MyBase.New(sqlResult, readerIndex, False)
       Me.Entity = sqlResult.Entity
       Me.Reader = entityReader
       Me.ContainsPKReader = containsPKReader

--- a/Source/Source/Yamo/Internal/Query/ExcludedUnknownSqlResult.vb
+++ b/Source/Source/Yamo/Internal/Query/ExcludedUnknownSqlResult.vb
@@ -17,7 +17,7 @@ Namespace Internal.Query
     ''' <param name="sqlResult"></param>
     ''' <param name="readerIndex"></param>
     Public Sub New(<DisallowNull> sqlResult As ExcludedUnknownSqlResult, readerIndex As Int32)
-      MyBase.New(sqlResult, readerIndex)
+      MyBase.New(sqlResult, readerIndex, False)
     End Sub
 
   End Class

--- a/Source/Source/Yamo/Internal/Query/Metadata/JoinInfo.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/JoinInfo.vb
@@ -30,13 +30,6 @@ Namespace Internal.Query.Metadata
     Public ReadOnly Property Subquery As <MaybeNull> SelectQuery
 
     ''' <summary>
-    ''' Gets non model entity creation behavior (if used).<br/>
-    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
-    ''' </summary>
-    ''' <returns></returns>
-    Public ReadOnly Property NonModelEntityCreationBehavior As NonModelEntityCreationBehavior
-
-    ''' <summary>
     ''' Creates new instance of <see cref="JoinInfo"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
@@ -52,7 +45,7 @@ Namespace Internal.Query.Metadata
     ''' <param name="joinType"></param>
     ''' <param name="tableSource"></param>
     Sub New(<DisallowNull> joinType As JoinType, tableSource As String)
-      Me.New(joinType, tableSource, Nothing, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull)
+      Me.New(joinType, tableSource, Nothing)
     End Sub
 
     ''' <summary>
@@ -62,12 +55,10 @@ Namespace Internal.Query.Metadata
     ''' <param name="joinType"></param>
     ''' <param name="tableSource"></param>
     ''' <param name="subquery"></param>
-    ''' <param name="creationBehavior"></param>
-    Sub New(<DisallowNull> joinType As JoinType, tableSource As String, subquery As SelectQuery, creationBehavior As NonModelEntityCreationBehavior)
+    Sub New(<DisallowNull> joinType As JoinType, tableSource As String, subquery As SelectQuery)
       Me.JoinType = joinType
       Me.TableSource = tableSource
       Me.Subquery = subquery
-      Me.NonModelEntityCreationBehavior = creationBehavior
     End Sub
 
   End Structure

--- a/Source/Source/Yamo/Internal/Query/Metadata/SqlResultBase.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/SqlResultBase.vb
@@ -20,7 +20,7 @@ Namespace Internal.Query.Metadata
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <returns></returns>
-    Public Property CreationBehavior As NonModelEntityCreationBehavior
+    Public ReadOnly Property CreationBehavior As NonModelEntityCreationBehavior
 
     ''' <summary>
     ''' Creates new instance of <see cref="SqlResultBase"/>.<br/>
@@ -29,9 +29,25 @@ Namespace Internal.Query.Metadata
     ''' <param name="resultType"></param>
     Public Sub New(<DisallowNull> resultType As Type)
       Me.ResultType = resultType
-      ' NOTE: probably better would be to set the default to NullIfAllColumnsAreNull.
-      ' It's like this for backward compatibility (to avoid breaking change in the behavior, since we won't be able to manage it for Include results at the moment).
-      Me.CreationBehavior = NonModelEntityCreationBehavior.AlwaysCreateInstance
+      Me.CreationBehavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull
+    End Sub
+
+    ''' <summary>
+    ''' Sets creation behavior unless <see cref="NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull"/> value is passed as a parameter.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="behavior"></param>
+    Public Sub UpdateCreationBehavior(behavior As NonModelEntityCreationBehavior)
+      ' NOTE: this method is called from custom select and include. Those two are mutually
+      ' exclusive, so it's not possible to call this method twice on the same result (i.e. this instance).
+      ' However, include can be called multiple times and theoretically on the same result, if
+      ' it originates from the subquery. This is a problem, because last call wins and all included
+      ' values will follow the same behavior.
+      ' Solution is to create new result instance (copy) if needed. However, this is an edge
+      ' case and we don't do it for now for the simplicity and allocation reasons.
+      If Not behavior = NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull Then
+        _CreationBehavior = behavior
+      End If
     End Sub
 
     ''' <summary>

--- a/Source/Source/Yamo/Internal/Query/ReaderDataBase.vb
+++ b/Source/Source/Yamo/Internal/Query/ReaderDataBase.vb
@@ -24,14 +24,23 @@ Namespace Internal.Query
     Public ReadOnly Property ReaderIndex As Int32
 
     ''' <summary>
+    ''' Gets whether contains non-null column check should be performed.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property ContainsNonNullColumnCheck As Boolean
+
+    ''' <summary>
     ''' Creates new instance of <see cref="ReaderDataBase"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="sqlResult"></param>
     ''' <param name="readerIndex"></param>
-    Protected Sub New(<DisallowNull> sqlResult As SqlResultBase, readerIndex As Int32)
+    ''' <param name="containsNonNullColumnCheck"></param>
+    Protected Sub New(<DisallowNull> sqlResult As SqlResultBase, readerIndex As Int32, containsNonNullColumnCheck As Boolean)
       Me.SqlResult = sqlResult
       Me.ReaderIndex = readerIndex
+      Me.ContainsNonNullColumnCheck = containsNonNullColumnCheck
     End Sub
 
     ''' <summary>

--- a/Source/Source/Yamo/Internal/Query/ScalarValueSqlResultReaderData.vb
+++ b/Source/Source/Yamo/Internal/Query/ScalarValueSqlResultReaderData.vb
@@ -25,7 +25,7 @@ Namespace Internal.Query
     ''' <param name="readerIndex"></param>
     ''' <param name="reader"></param>
     Public Sub New(<DisallowNull> sqlResult As ScalarValueSqlResult, readerIndex As Int32, <DisallowNull> reader As Object)
-      MyBase.New(sqlResult, readerIndex)
+      MyBase.New(sqlResult, readerIndex, False)
       Me.Reader = reader
     End Sub
 

--- a/Source/Source/Yamo/Internal/Query/ValueTupleSqlResultReaderData.vb
+++ b/Source/Source/Yamo/Internal/Query/ValueTupleSqlResultReaderData.vb
@@ -25,7 +25,12 @@ Namespace Internal.Query
     ''' <param name="readerIndex"></param>
     ''' <param name="items"></param>
     Public Sub New(<DisallowNull> sqlResult As ValueTupleSqlResult, readerIndex As Int32, <DisallowNull> items As ReaderDataBase())
-      MyBase.New(sqlResult, readerIndex)
+      ' NOTE: in some cases, honoring NullIfAllColumnsAreNull is not necessary and AlwaysCreateInstance could be used.
+      ' I.e. when ValueTuple is not nullable. Default is an empty value tuple and not null in that case.
+      ' However, we simply cannot only check nullability here. For example, if the result is an include call and we are
+      ' setting the value to a property of type Object, we still expect null to be set.
+      ' Also, it is questionable, if using AlwaysCreateInstance would be faster. It might even be slower (depending on the result).
+      MyBase.New(sqlResult, readerIndex, Not sqlResult.CreationBehavior = NonModelEntityCreationBehavior.AlwaysCreateInstance)
       Me.Items = items
     End Sub
 

--- a/Source/Source/Yamo/NonModelEntityCreationBehavior.vb
+++ b/Source/Source/Yamo/NonModelEntityCreationBehavior.vb
@@ -4,11 +4,15 @@
 ''' </summary>
 Public Enum NonModelEntityCreationBehavior
   ''' <summary>
+  ''' If possible, infer the behavior from the subquery result. Otherwise, use <see cref="NullIfAllColumnsAreNull"/> behavior.
+  ''' </summary>
+  InferOrNullIfAllColumnsAreNull = 0
+  ''' <summary>
   ''' Do not create an instance unless there is at least one related column value in the resultset that doesn't equal to <see cref="DBNull"/>.
   ''' </summary>
-  NullIfAllColumnsAreNull = 0
+  NullIfAllColumnsAreNull = 1
   ''' <summary>
   ''' Always create an instance, even if all related columns in the resultset contain <see cref="DBNull"/> value.
   ''' </summary>
-  AlwaysCreateInstance = 1
+  AlwaysCreateInstance = 2
 End Enum

--- a/Source/Source/Yamo/SubqueryContext.vb
+++ b/Source/Source/Yamo/SubqueryContext.vb
@@ -51,10 +51,9 @@ Public Class SubqueryContext
   ''' </summary>
   ''' <typeparam name="T"></typeparam>
   ''' <param name="tableSourceFactory"></param>
-  ''' <param name="behavior"></param>
   ''' <returns></returns>
-  Public Function From(Of T)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As SelectSqlExpression(Of T)
-    Return New SelectSqlExpression(Of T)(Me, tableSourceFactory, behavior)
+  Public Function From(Of T)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SelectSqlExpression(Of T)
+    Return New SelectSqlExpression(Of T)(Me, tableSourceFactory)
   End Function
 
   ''' <summary>

--- a/Source/Test/Yamo.Test/Model/NonModelObject.vb
+++ b/Source/Test/Yamo.Test/Model/NonModelObject.vb
@@ -12,6 +12,8 @@
 
     Public Property IntValue As Int32
 
+    Public Property NullableIntValue As Int32?
+
     Public Property DecimalValue As Decimal
 
     Public Property NullableDecimalValue As Decimal?
@@ -77,6 +79,7 @@
         If Not Object.Equals(Me.StringValue1, o.StringValue1) Then Return False
         If Not Object.Equals(Me.StringValue2, o.StringValue2) Then Return False
         If Not Object.Equals(Me.IntValue, o.IntValue) Then Return False
+        If Not Object.Equals(Me.NullableIntValue, o.NullableIntValue) Then Return False
         If Not Object.Equals(Me.DecimalValue, o.DecimalValue) Then Return False
         If Not Object.Equals(Me.NullableDecimalValue, o.NullableDecimalValue) Then Return False
 
@@ -85,7 +88,7 @@
     End Function
 
     Public Overrides Function GetHashCode() As Int32
-      Return HashCode.Combine(Me.GuidValue, Me.BooleanValue, Me.StringValue1, Me.StringValue2, Me.IntValue, Me.DecimalValue, Me.NullableDecimalValue)
+      Return HashCode.Combine(Me.GuidValue, Me.BooleanValue, Me.StringValue1, Me.StringValue2, Me.IntValue, Me.NullableIntValue, Me.DecimalValue, Me.NullableDecimalValue)
     End Function
 
   End Class

--- a/Source/Test/Yamo.Test/Tests/CustomSelectTests.vb
+++ b/Source/Test/Yamo.Test/Tests/CustomSelectTests.vb
@@ -2400,15 +2400,34 @@ Namespace Tests
                         LeftJoin(Function(c)
                                    Return c.From(Of Label).
                                             Where(Function(x) x.Language = English).
-                                            Select(Function(x) New With {Key .Id = x.Id, Key .Label = x, Key .Description = x.Description})
-                                 End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                                            Select(Function(x) New With {Key .Id = x.Id, Key .Label = x, Key .Description = x.Description}, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull)
+                                 End Function).
                         On(Function(j) j.T1.Id = j.T2.Id).
                         OrderBy(Function(j) j.T1.Id).
                         Select(Function(j) j.T2).
                         ToList()
 
-        Assert.AreEqual(1, result.Count)
+        Assert.AreEqual(2, result.Count)
         Assert.AreEqual(New With {Key .Id = label1En.Id, Key .Label = label1En, Key .Description = label1En.Description}, result(0))
+        Assert.IsNull(result(1))
+      End Using
+
+      ' same as above, but assume infer behavior
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) New With {Key .Id = x.Id, Key .Label = x, Key .Description = x.Description}, NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull)
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T1.Id).
+                        Select(Function(j) j.T2).
+                        ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(New With {Key .Id = label1En.Id, Key .Label = label1En, Key .Description = label1En.Description}, result(0))
+        Assert.IsNull(result(1))
       End Using
 
       ' same as above, but assume behavior is not explicitly set
@@ -2424,8 +2443,27 @@ Namespace Tests
                         Select(Function(j) j.T2).
                         ToList()
 
-        Assert.AreEqual(1, result.Count)
+        Assert.AreEqual(2, result.Count)
         Assert.AreEqual(New With {Key .Id = label1En.Id, Key .Label = label1En, Key .Description = label1En.Description}, result(0))
+        Assert.IsNull(result(1))
+      End Using
+
+      ' override behavior
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) New With {Key .Id = x.Id, Key .Label = x, Key .Description = x.Description}, NonModelEntityCreationBehavior.AlwaysCreateInstance)
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T1.Id).
+                        Select(Function(j) j.T2, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(New With {Key .Id = label1En.Id, Key .Label = label1En, Key .Description = label1En.Description}, result(0))
+        Assert.IsNull(result(1))
       End Using
     End Sub
 
@@ -2443,11 +2481,29 @@ Namespace Tests
                         LeftJoin(Function(c)
                                    Return c.From(Of Label).
                                             Where(Function(x) x.Language = English).
-                                            Select(Function(x) New With {Key .Id = x.Id, Key .Label = x, Key .Description = x.Description})
-                                 End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                                            Select(Function(x) New With {Key .Id = x.Id, Key .Label = x, Key .Description = x.Description}, NonModelEntityCreationBehavior.AlwaysCreateInstance)
+                                 End Function).
                         On(Function(j) j.T1.Id = j.T2.Id).
                         OrderBy(Function(j) j.T1.Id).
                         Select(Function(j) j.T2).
+                        ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(New With {Key .Id = label1En.Id, Key .Label = label1En, Key .Description = label1En.Description}, result(0))
+        Assert.AreEqual(New With {Key .Id = 0, Key .Label = CType(Nothing, Label), Key .Description = CType(Nothing, String)}, result(1))
+      End Using
+
+      ' override behavior
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) New With {Key .Id = x.Id, Key .Label = x, Key .Description = x.Description}, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull)
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T1.Id).
+                        Select(Function(j) j.T2, NonModelEntityCreationBehavior.AlwaysCreateInstance).
                         ToList()
 
         Assert.AreEqual(2, result.Count)

--- a/Source/Test/Yamo.Test/Tests/SelectWithFromSubqueryTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithFromSubqueryTests.vb
@@ -292,14 +292,31 @@ Namespace Tests
         Dim result = db.From(Function(c)
                                Return c.From(Of Article).
                                         LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
-                                        Select(Function(x) x.T2)
-                             End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                                        Select(Function(x) x.T2, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull)
+                             End Function).
                         OrderBy(Function(x) x.Id).
                         SelectAll().ToList()
 
-        Assert.AreEqual(2, result.Count)
-        Assert.AreEqual(label1En, result(0))
-        Assert.AreEqual(label3En, result(1))
+        Assert.AreEqual(3, result.Count)
+        Assert.IsNull(result(0))
+        Assert.AreEqual(label1En, result(1))
+        Assert.AreEqual(label3En, result(2))
+      End Using
+
+      ' same as above, but assume infer behavior
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(x) x.T2, NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull)
+                             End Function).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.IsNull(result(0))
+        Assert.AreEqual(label1En, result(1))
+        Assert.AreEqual(label3En, result(2))
       End Using
 
       ' same as above, but assume behavior is not explicitly set
@@ -312,9 +329,10 @@ Namespace Tests
                         OrderBy(Function(x) x.Id).
                         SelectAll().ToList()
 
-        Assert.AreEqual(2, result.Count)
-        Assert.AreEqual(label1En, result(0))
-        Assert.AreEqual(label3En, result(1))
+        Assert.AreEqual(3, result.Count)
+        Assert.IsNull(result(0))
+        Assert.AreEqual(label1En, result(1))
+        Assert.AreEqual(label3En, result(2))
       End Using
     End Sub
 
@@ -335,14 +353,15 @@ Namespace Tests
         Dim result = db.From(Function(c)
                                Return c.From(Of Article).
                                         LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
-                                        Select(Function(x) x.T2)
-                             End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                                        Select(Function(x) x.T2, NonModelEntityCreationBehavior.AlwaysCreateInstance)
+                             End Function).
                         OrderBy(Function(x) x.Id).
                         SelectAll().ToList()
 
-        Assert.AreEqual(2, result.Count)
-        Assert.AreEqual(label1En, result(0))
-        Assert.AreEqual(label3En, result(1))
+        Assert.AreEqual(3, result.Count)
+        Assert.IsNull(result(0))
+        Assert.AreEqual(label1En, result(1))
+        Assert.AreEqual(label3En, result(2))
       End Using
     End Sub
 
@@ -364,14 +383,31 @@ Namespace Tests
         Dim result = db.From(Function(c)
                                Return c.From(Of Article).
                                         LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
-                                        Select(Function(j) New With {Key .Id = j.T2.Id, Key .Description = j.T2.Description})
-                             End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                                        Select(Function(j) New With {Key .Id = j.T2.Id, Key .Description = j.T2.Description}, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull)
+                             End Function).
                         OrderBy(Function(x) x.Id).
                         SelectAll().ToList()
 
-        Assert.AreEqual(2, result.Count)
-        Assert.AreEqual(item1, result(0))
-        Assert.AreEqual(item3, result(1))
+        Assert.AreEqual(3, result.Count)
+        Assert.IsNull(result(0))
+        Assert.AreEqual(item1, result(1))
+        Assert.AreEqual(item3, result(2))
+      End Using
+
+      ' same as above, but assume infer behavior
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(j) New With {Key .Id = j.T2.Id, Key .Description = j.T2.Description}, NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull)
+                             End Function).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.IsNull(result(0))
+        Assert.AreEqual(item1, result(1))
+        Assert.AreEqual(item3, result(2))
       End Using
 
       ' same as above, but assume behavior is not explicitly set
@@ -384,9 +420,10 @@ Namespace Tests
                         OrderBy(Function(x) x.Id).
                         SelectAll().ToList()
 
-        Assert.AreEqual(2, result.Count)
-        Assert.AreEqual(item1, result(0))
-        Assert.AreEqual(item3, result(1))
+        Assert.AreEqual(3, result.Count)
+        Assert.IsNull(result(0))
+        Assert.AreEqual(item1, result(1))
+        Assert.AreEqual(item3, result(2))
       End Using
     End Sub
 
@@ -409,8 +446,8 @@ Namespace Tests
         Dim result = db.From(Function(c)
                                Return c.From(Of Article).
                                         LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
-                                        Select(Function(j) New With {Key .Id = j.T2.Id, Key .Description = j.T2.Description})
-                             End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                                        Select(Function(j) New With {Key .Id = j.T2.Id, Key .Description = j.T2.Description}, NonModelEntityCreationBehavior.AlwaysCreateInstance)
+                             End Function).
                         OrderBy(Function(x) x.Id).
                         SelectAll().ToList()
 
@@ -434,19 +471,37 @@ Namespace Tests
 
       Dim item1 = (Id:=label1En.Id, Description:=label1En.Description)
       Dim item3 = (Id:=label3En.Id, Description:=label3En.Description)
+      Dim itemEmpty = (Id:=0, Description:=CType(Nothing, String))
 
       Using db = CreateDbContext()
         Dim result = db.From(Function(c)
                                Return c.From(Of Article).
                                         LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
-                                        Select(Function(j) (Id:=j.T2.Id, Description:=j.T2.Description))
-                             End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                                        Select(Function(j) (Id:=j.T2.Id, Description:=j.T2.Description), NonModelEntityCreationBehavior.NullIfAllColumnsAreNull)
+                             End Function).
                         OrderBy(Function(x) x.Id).
                         SelectAll().ToList()
 
-        Assert.AreEqual(2, result.Count)
-        Assert.AreEqual(item1, result(0))
-        Assert.AreEqual(item3, result(1))
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(itemEmpty, result(0)) ' because this is value type, it won't be null
+        Assert.AreEqual(item1, result(1))
+        Assert.AreEqual(item3, result(2))
+      End Using
+
+      ' same as above, but assume infer behavior
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(j) (Id:=j.T2.Id, Description:=j.T2.Description), NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull)
+                             End Function).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(itemEmpty, result(0)) ' because this is value type, it won't be null
+        Assert.AreEqual(item1, result(1))
+        Assert.AreEqual(item3, result(2))
       End Using
 
       ' same as above, but assume behavior is not explicitly set
@@ -459,9 +514,10 @@ Namespace Tests
                         OrderBy(Function(x) x.Id).
                         SelectAll().ToList()
 
-        Assert.AreEqual(2, result.Count)
-        Assert.AreEqual(item1, result(0))
-        Assert.AreEqual(item3, result(1))
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(itemEmpty, result(0)) ' because this is value type, it won't be null
+        Assert.AreEqual(item1, result(1))
+        Assert.AreEqual(item3, result(2))
       End Using
     End Sub
 
@@ -484,8 +540,8 @@ Namespace Tests
         Dim result = db.From(Function(c)
                                Return c.From(Of Article).
                                         LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
-                                        Select(Function(j) (Id:=j.T2.Id, Description:=j.T2.Description))
-                             End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                                        Select(Function(j) (Id:=j.T2.Id, Description:=j.T2.Description), NonModelEntityCreationBehavior.AlwaysCreateInstance)
+                             End Function).
                         OrderBy(Function(x) x.Id).
                         SelectAll().ToList()
 
@@ -514,14 +570,31 @@ Namespace Tests
         Dim result = db.From(Function(c)
                                Return c.From(Of Article).
                                         LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
-                                        Select(Function(j) New NonModelObject With {.IntValue = j.T2.Id, .StringValue1 = j.T2.Description})
-                             End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                                        Select(Function(j) New NonModelObject With {.IntValue = j.T2.Id, .StringValue1 = j.T2.Description}, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull)
+                             End Function).
                         OrderBy(Function(x) x.IntValue).
                         SelectAll().ToList()
 
-        Assert.AreEqual(2, result.Count)
-        Assert.AreEqual(item1, result(0))
-        Assert.AreEqual(item3, result(1))
+        Assert.AreEqual(3, result.Count)
+        Assert.IsNull(result(0))
+        Assert.AreEqual(item1, result(1))
+        Assert.AreEqual(item3, result(2))
+      End Using
+
+      ' same as above, but assume infer behavior
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(j) New NonModelObject With {.IntValue = j.T2.Id, .StringValue1 = j.T2.Description}, NonModelEntityCreationBehavior.InferOrNullIfAllColumnsAreNull)
+                             End Function).
+                        OrderBy(Function(x) x.IntValue).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.IsNull(result(0))
+        Assert.AreEqual(item1, result(1))
+        Assert.AreEqual(item3, result(2))
       End Using
 
       ' same as above, but assume behavior is not explicitly set
@@ -534,9 +607,10 @@ Namespace Tests
                         OrderBy(Function(x) x.IntValue).
                         SelectAll().ToList()
 
-        Assert.AreEqual(2, result.Count)
-        Assert.AreEqual(item1, result(0))
-        Assert.AreEqual(item3, result(1))
+        Assert.AreEqual(3, result.Count)
+        Assert.IsNull(result(0))
+        Assert.AreEqual(item1, result(1))
+        Assert.AreEqual(item3, result(2))
       End Using
     End Sub
 
@@ -559,8 +633,8 @@ Namespace Tests
         Dim result = db.From(Function(c)
                                Return c.From(Of Article).
                                         LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
-                                        Select(Function(j) New NonModelObject With {.IntValue = j.T2.Id, .StringValue1 = j.T2.Description})
-                             End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                                        Select(Function(j) New NonModelObject With {.IntValue = j.T2.Id, .StringValue1 = j.T2.Description}, NonModelEntityCreationBehavior.AlwaysCreateInstance)
+                             End Function).
                         OrderBy(Function(x) x.IntValue).
                         SelectAll().ToList()
 


### PR DESCRIPTION
PR #97 introduced optional `NonModelEntityCreationBehavior` parameter for `Join` methods and later #98 used it as well in `From` method.

Parameter defines, whether to create values of non model entities (i.e. anonymous types, non-model ad hoc types and value tuples), since those don't have primary key defined in the model.

This PR moves the parameter directly to the `Select` method. It seems to be a better fit and enables more use cases (even for selects without a subquery). Additionally, there is now an option to use it in the `Include` method.

There are 3 possible values now:
- `InferOrNullIfAllColumnsAreNull` - infer the behavior (from the subquery) or use value `NullIfAllColumnsAreNull` if it cannot be inferred. This is the default value.
- `NullIfAllColumnsAreNull` - do not create an instance unless there is at least one related column value in the resultset that doesn't equal to `DBNull`.
- `AlwaysCreateInstance` - always create an instance, even if all related columns in the resultset contain `DBNull` value.

Examples:
```cs
using (var db = CreateContext())
{
    var list = db.From<Article>()
                 .LeftJoin<Label>(j => j.T1.Id == j.T2.Id && j.T2.Id < 2)
                 .Select(j => new { j.T2.Id, j.T2.Description }, NonModelEntityCreationBehavior.AlwaysCreateInstance)
                 .ToList();
}
```

```cs
using (var db = CreateContext())
{
    var list = db.From<Article>()
                 .LeftJoin<Label>(j => j.T1.Id == j.T2.Id && j.T2.Id < 2)
                 .SelectAll()
                 .Include(j => j.T1.Tag, j => new { j.T2.Id, j.T2.Description }, NonModelEntityCreationBehavior.AlwaysCreateInstance)
                 .ToList();
}
```

If needed, behavior can be overridden. Although, this will be probably needed only in some special edge cases.
```cs
using (var db = CreateContext())
{
    // NullIfAllColumnsAreNull overrides AlwaysCreateInstance behavior
    var list = db.From<Article>()
                 .LeftJoin(c =>
                 {
                     return c.From<ArticleCategory>()
                             .GroupBy(x => x.ArticleId)
                             .Select(x => new Stats { ArticleId = x.ArticleId, CategoriesCount = Yamo.Sql.Aggregate.Count() }, NonModelEntityCreationBehavior.AlwaysCreateInstance);
                 })
                 .On(j => j.T1.Id == j.T2.ArticleId)
                 .Select(j => j.T2, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull)
                 .ToList();
}
```

This PR contains breaking changes.