### PR TITLE
Added support for ISelectFilterProvider and ISelectSortProvider

### DIFF
--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.OrderBy.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.OrderBy.vb
@@ -22,6 +22,14 @@
       GenerateOrderByWithString(builder, entityCount)
       builder.AppendLine()
 
+      If entityCount = 1 Then
+        GenerateOrderByWithProviderWithOneEntity(builder, entityCount)
+        builder.AppendLine()
+      Else
+        GenerateOrderByWithProviderWithIJoin(builder, entityCount)
+        builder.AppendLine()
+      End If
+
       For i = 1 To entityCount
         GenerateOrderByDescendingWithPredicateWithOneEntity(builder, i, entityCount)
         builder.AppendLine()
@@ -97,7 +105,7 @@
     End Sub
 
     Protected Sub GenerateOrderByWithString(builder As CodeBuilder, entityCount As Int32)
-      Dim comment = "Adds ORDER BY DESC clause."
+      Dim comment = "Adds ORDER BY clause."
       Dim params = {"predicate", "parameters"}
       AddComment(builder, comment, params:=params, returns:="")
 
@@ -105,6 +113,32 @@
 
       builder.Indent().AppendLine($"Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
       builder.Indent().AppendLine("Me.Builder.AddOrderBy(predicate, True, parameters)")
+      builder.Indent().AppendLine($"Return New OrderedSelectSqlExpression(Of {generics})(Me.Builder, Me.Executor)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateOrderByWithProviderWithOneEntity(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds ORDER BY clause."
+      Dim params = {"provider"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"provider.AddOrderBy(Of {generics})(Me.Builder)")
+      builder.Indent().AppendLine($"Return New OrderedSelectSqlExpression(Of {generics})(Me.Builder, Me.Executor)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateOrderByWithProviderWithIJoin(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds ORDER BY clause."
+      Dim params = {"provider"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"provider.AddOrderBy(Of Join(Of {generics}))(Me.Builder)")
       builder.Indent().AppendLine($"Return New OrderedSelectSqlExpression(Of {generics})(Me.Builder, Me.Executor)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.ThenBy.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.ThenBy.vb
@@ -22,6 +22,14 @@
       GenerateThenByWithString(builder, entityCount)
       builder.AppendLine()
 
+      If entityCount = 1 Then
+        GenerateThenByWithProviderWithOneEntity(builder, entityCount)
+        builder.AppendLine()
+      Else
+        GenerateThenByWithProviderWithIJoin(builder, entityCount)
+        builder.AppendLine()
+      End If
+
       For i = 1 To entityCount
         GenerateThenByDescendingWithPredicateWithOneEntity(builder, i, entityCount)
         builder.AppendLine()
@@ -105,6 +113,32 @@
 
       builder.Indent().AppendLine($"Public Function ThenBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
       builder.Indent().AppendLine("Me.Builder.AddOrderBy(predicate, True, parameters)")
+      builder.Indent().AppendLine("Return Me").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateThenByWithProviderWithOneEntity(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds column(s) to ORDER BY clause."
+      Dim params = {"provider"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"provider.AddOrderBy(Of {generics})(Me.Builder)")
+      builder.Indent().AppendLine("Return Me").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateThenByWithProviderWithIJoin(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds column(s) to ORDER BY clause."
+      Dim params = {"provider"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"provider.AddOrderBy(Of Join(Of {generics}))(Me.Builder)")
       builder.Indent().AppendLine("Return Me").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Where.And.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Where.And.vb
@@ -30,6 +30,14 @@
       GenerateWhereAndWithString(builder, entityCount)
       builder.AppendLine()
 
+      If entityCount = 1 Then
+        GenerateWhereAndWithProviderWithOneEntity(builder, entityCount)
+        builder.AppendLine()
+      Else
+        GenerateWhereAndWithProviderWithIJoin(builder, entityCount)
+        builder.AppendLine()
+      End If
+
       GenerateInternalWhereForWhereAnd(builder, entityCount)
     End Sub
 
@@ -116,6 +124,32 @@
 
       builder.Indent().AppendLine($"Public Function [And](<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of {generics})").PushIndent()
       builder.Indent().AppendLine("Me.Builder.AddWhere(predicate, parameters)")
+      builder.Indent().AppendLine("Return Me").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateWhereAndWithProviderWithOneEntity(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds AND condition(s) to WHERE clause."
+      Dim params = {"provider"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"provider.AddWhere(Of {generics})(Me.Builder)")
+      builder.Indent().AppendLine("Return Me").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateWhereAndWithProviderWithIJoin(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds AND condition(s) to WHERE clause."
+      Dim params = {"provider"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"provider.AddWhere(Of Join(Of {generics}))(Me.Builder)")
       builder.Indent().AppendLine("Return Me").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Where.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Where.vb
@@ -30,6 +30,14 @@
       GenerateWhereWithString(builder, entityCount)
       builder.AppendLine()
 
+      If entityCount = 1 Then
+        GenerateWhereWithProviderWithOneEntity(builder, entityCount)
+        builder.AppendLine()
+      Else
+        GenerateWhereWithProviderWithIJoin(builder, entityCount)
+        builder.AppendLine()
+      End If
+
       GenerateParameterlessWhere(builder, entityCount)
       builder.AppendLine()
 
@@ -119,6 +127,32 @@
 
       builder.Indent().AppendLine($"Public Function Where(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of {generics})").PushIndent()
       builder.Indent().AppendLine("Me.Builder.AddWhere(predicate, parameters)")
+      builder.Indent().AppendLine($"Return New FilteredSelectSqlExpression(Of {generics})(Me.Builder, Me.Executor)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateWhereWithProviderWithOneEntity(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds WHERE clause."
+      Dim params = {"provider"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"provider.AddWhere(Of {generics})(Me.Builder)")
+      builder.Indent().AppendLine($"Return New FilteredSelectSqlExpression(Of {generics})(Me.Builder, Me.Executor)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateWhereWithProviderWithIJoin(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds WHERE clause."
+      Dim params = {"provider"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"provider.AddWhere(Of Join(Of {generics}))(Me.Builder)")
       builder.Indent().AppendLine($"Return New FilteredSelectSqlExpression(Of {generics})(Me.Builder, Me.Executor)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub

--- a/Source/Source/Yamo/Expressions/Builders/SelectSqlExpressionBuilder.vb
+++ b/Source/Source/Yamo/Expressions/Builders/SelectSqlExpressionBuilder.vb
@@ -1088,6 +1088,15 @@ Namespace Expressions.Builders
     End Sub
 
     ''' <summary>
+    ''' Gets SQL model.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function GetModel() As SelectSqlModel
+      Return m_Model
+    End Function
+
+    ''' <summary>
     ''' Creates query.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
@@ -51,6 +51,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T)
+      provider.AddWhere(Of T)(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -103,13 +113,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T)
+      provider.AddOrderBy(Of T)(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
@@ -106,6 +106,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2)
+      provider.AddWhere(Of Join(Of T1, T2))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -226,13 +236,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2)
+      provider.AddOrderBy(Of Join(Of T1, T2))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
@@ -125,6 +125,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3)
+      provider.AddWhere(Of Join(Of T1, T2, T3))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -274,13 +284,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
@@ -126,6 +126,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -304,13 +314,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -145,6 +145,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -352,13 +362,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -164,6 +164,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -400,13 +410,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -183,6 +183,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -448,13 +458,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -202,6 +202,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -486,13 +496,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -221,6 +221,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -534,13 +544,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -240,6 +240,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -582,13 +592,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -259,6 +259,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -630,13 +640,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -278,6 +278,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -678,13 +688,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -297,6 +297,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -726,13 +736,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -316,6 +316,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -774,13 +784,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -335,6 +335,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -822,13 +832,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -354,6 +354,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -870,13 +880,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -373,6 +373,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -918,13 +928,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -392,6 +392,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -966,13 +976,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -411,6 +411,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -1014,13 +1024,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -430,6 +430,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -1062,13 +1072,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -449,6 +449,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -1110,13 +1120,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -468,6 +468,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -1158,13 +1168,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -487,6 +487,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -1206,13 +1216,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -506,6 +506,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -1254,13 +1264,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -525,6 +525,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds AND condition(s) to WHERE clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function [And](<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
@@ -1302,13 +1312,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
@@ -89,13 +89,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T)
+      provider.AddOrderBy(Of T)(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
@@ -182,13 +182,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2)
+      provider.AddOrderBy(Of Join(Of T1, T2))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
@@ -220,13 +220,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
@@ -240,13 +240,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -278,13 +278,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -316,13 +316,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -354,13 +354,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -392,13 +392,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -430,13 +430,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -468,13 +468,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -506,13 +506,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -544,13 +544,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -582,13 +582,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -620,13 +620,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -658,13 +658,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -696,13 +696,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -734,13 +734,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -772,13 +772,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -810,13 +810,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -848,13 +848,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -886,13 +886,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -924,13 +924,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -962,13 +962,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -1000,13 +1000,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1038,13 +1038,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
@@ -81,13 +81,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T)
+      provider.AddOrderBy(Of T)(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
@@ -174,13 +174,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2)
+      provider.AddOrderBy(Of Join(Of T1, T2))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
@@ -212,13 +212,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
@@ -232,13 +232,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -270,13 +270,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -308,13 +308,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -346,13 +346,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -384,13 +384,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -422,13 +422,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -460,13 +460,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -498,13 +498,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -536,13 +536,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -574,13 +574,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -612,13 +612,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -650,13 +650,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -688,13 +688,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -726,13 +726,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -764,13 +764,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -802,13 +802,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -840,13 +840,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -878,13 +878,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -916,13 +916,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -954,13 +954,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -992,13 +992,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1030,13 +1030,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpression.vb
@@ -52,6 +52,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T)
+      provider.AddOrderBy(Of T)(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2.vb
@@ -91,6 +91,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2)
+      provider.AddOrderBy(Of Join(Of T1, T2))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3.vb
@@ -111,6 +111,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4.vb
@@ -131,6 +131,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -151,6 +151,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -171,6 +171,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -191,6 +191,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -211,6 +211,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -231,6 +231,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -251,6 +251,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -271,6 +271,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -291,6 +291,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -311,6 +311,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -331,6 +331,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -351,6 +351,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -371,6 +371,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -391,6 +391,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -411,6 +411,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -431,6 +431,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -451,6 +451,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -471,6 +471,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -491,6 +491,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -511,6 +511,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -531,6 +531,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -551,6 +551,16 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds column(s) to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25))(Me.Builder)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
@@ -480,6 +480,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T)
+      provider.AddWhere(Of T)(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T)
       Return New FilteredSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
@@ -538,13 +548,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T)
+      provider.AddOrderBy(Of T)(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
@@ -536,6 +536,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2)
+      provider.AddWhere(Of Join(Of T1, T2))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2)
       Return New FilteredSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
@@ -662,13 +672,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2)
+      provider.AddOrderBy(Of Join(Of T1, T2))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
@@ -555,6 +555,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3)
+      provider.AddWhere(Of Join(Of T1, T2, T3))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
@@ -710,13 +720,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
@@ -596,6 +596,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
@@ -780,13 +790,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
@@ -655,6 +655,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
@@ -868,13 +878,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -714,6 +714,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
@@ -956,13 +966,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -493,6 +493,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
@@ -764,13 +774,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -512,6 +512,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
@@ -802,13 +812,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -531,6 +531,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
@@ -850,13 +860,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -550,6 +550,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
@@ -898,13 +908,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -569,6 +569,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
@@ -946,13 +956,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -588,6 +588,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
@@ -994,13 +1004,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -607,6 +607,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
@@ -1042,13 +1052,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -626,6 +626,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
@@ -1090,13 +1100,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -645,6 +645,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
@@ -1138,13 +1148,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -664,6 +664,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
@@ -1186,13 +1196,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -683,6 +683,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
@@ -1234,13 +1244,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -702,6 +702,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
@@ -1282,13 +1292,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -721,6 +721,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
@@ -1330,13 +1340,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -740,6 +740,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
@@ -1378,13 +1388,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -759,6 +759,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
@@ -1426,13 +1436,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -778,6 +778,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
@@ -1474,13 +1484,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -797,6 +797,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
@@ -1522,13 +1532,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -816,6 +816,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
@@ -1570,13 +1580,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -528,6 +528,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      provider.AddWhere(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25))(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
@@ -1311,13 +1321,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      provider.AddOrderBy(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25))(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/WithHintsSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/WithHintsSelectSqlExpression.vb
@@ -401,6 +401,16 @@ Namespace Expressions
     ''' <summary>
     ''' Adds WHERE clause.
     ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function Where(<DisallowNull> provider As ISelectFilterProvider) As FilteredSelectSqlExpression(Of T)
+      provider.AddWhere(Of T)(Me.Builder)
+      Return New FilteredSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
     ''' <returns></returns>
     Public Function Where() As FilteredSelectSqlExpression(Of T)
       Return New FilteredSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
@@ -459,13 +469,23 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds ORDER BY DESC clause.
+    ''' Adds ORDER BY clause.
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
     Public Function OrderBy(<DisallowNull> predicate As String, <DisallowNull> ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
       Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="provider"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(<DisallowNull> provider As ISelectSortProvider) As OrderedSelectSqlExpression(Of T)
+      provider.AddOrderBy(Of T)(Me.Builder)
       Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/ISelectFilterProvider.vb
+++ b/Source/Source/Yamo/ISelectFilterProvider.vb
@@ -1,0 +1,15 @@
+﻿Imports Yamo.Expressions.Builders
+
+''' <summary>
+''' Interface for SQL SELECT statement filter provider.
+''' </summary>
+Public Interface ISelectFilterProvider
+
+  ''' <summary>
+  ''' Adds condition(s) to WHERE clause.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <param name="builder"></param>
+  Sub AddWhere(Of T)(builder As SelectSqlExpressionBuilder)
+
+End Interface

--- a/Source/Source/Yamo/ISelectSortProvider.vb
+++ b/Source/Source/Yamo/ISelectSortProvider.vb
@@ -1,0 +1,15 @@
+﻿Imports Yamo.Expressions.Builders
+
+''' <summary>
+''' Interface for SQL SELECT statement sort provider.
+''' </summary>
+Public Interface ISelectSortProvider
+
+  ''' <summary>
+  ''' Adds column(s) to ORDER BY clause.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <param name="builder"></param>
+  Sub AddOrderBy(Of T)(builder As SelectSqlExpressionBuilder)
+
+End Interface

--- a/Source/Test/Yamo.Test/Tests/SelectWithSortTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithSortTests.vb
@@ -326,5 +326,52 @@ Namespace Tests
       End Using
     End Sub
 
+    <TestMethod()>
+    Public Overridable Sub SelectWithOrderBySortProvider()
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English, "a")
+      Dim label1De = Me.ModelFactory.CreateLabel("", 1, German, "b")
+      Dim label2En = Me.ModelFactory.CreateLabel("", 2, English, "c")
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German, "d")
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English, "e")
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German, "f")
+
+      InsertItems(label1En, label1De, label2En, label2De, label3En, label3De)
+
+      Dim provider = New TestSelectSortProvider()
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Label).
+                        Where(Function(l) l.Language = English).
+                        OrderBy(provider).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual("a", result(0).Description)
+        Assert.AreEqual("c", result(1).Description)
+        Assert.AreEqual("e", result(2).Description)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Label).
+                        OrderBy(Function(l) l.Language).
+                        ThenBy(provider).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(6, result.Count)
+        Assert.AreEqual(German, result(0).Language)
+        Assert.AreEqual("b", result(0).Description)
+        Assert.AreEqual(German, result(1).Language)
+        Assert.AreEqual("d", result(1).Description)
+        Assert.AreEqual(German, result(2).Language)
+        Assert.AreEqual("f", result(2).Description)
+        Assert.AreEqual(English, result(3).Language)
+        Assert.AreEqual("a", result(3).Description)
+        Assert.AreEqual(English, result(4).Language)
+        Assert.AreEqual("c", result(4).Description)
+        Assert.AreEqual(English, result(5).Language)
+        Assert.AreEqual("e", result(5).Description)
+      End Using
+    End Sub
+
   End Class
 End Namespace

--- a/Source/Test/Yamo.Test/Tests/SelectWithWhereTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithWhereTests.vb
@@ -1337,6 +1337,38 @@ Namespace Tests
       End Using
     End Sub
 
+    <TestMethod()>
+    Public Overridable Sub SelectRecordByFilterProvider()
+      Dim items = CreateItems()
+
+      items(0).IntColumn = 1
+      items(1).IntColumn = 2
+      items(2).IntColumn = 3
+      items(3).IntColumn = 4
+      items(4).IntColumn = 5
+
+      InsertItems(items)
+
+      Dim provider = New TestSelectFilterProvider()
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(provider).
+                        SelectAll().ToList()
+        Assert.AreEqual(3, result.Count)
+        CollectionAssert.AreEquivalent({items(0), items(1), items(2)}, result)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) 1 < x.IntColumn).
+                        And(provider).
+                        SelectAll().ToList()
+        Assert.AreEqual(2, result.Count)
+        CollectionAssert.AreEquivalent({items(1), items(2)}, result)
+      End Using
+    End Sub
+
     Protected Overridable Function CreateItems() As List(Of ItemWithAllSupportedValues)
       Return New List(Of ItemWithAllSupportedValues) From {
         Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues(),

--- a/Source/Test/Yamo.Test/Tests/TestSelectFilterProvider.vb
+++ b/Source/Test/Yamo.Test/Tests/TestSelectFilterProvider.vb
@@ -1,0 +1,24 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo
+Imports Yamo.Expressions.Builders
+Imports Yamo.Test.Model
+
+Namespace Tests
+
+  Public Class TestSelectFilterProvider
+    Implements ISelectFilterProvider
+
+    Public Sub AddWhere(Of T)(builder As SelectSqlExpressionBuilder) Implements ISelectFilterProvider.AddWhere
+      If GetType(T) IsNot GetType(ItemWithAllSupportedValues) Then
+        Throw New NotSupportedException
+      End If
+
+      builder.AddWhere(GetFilter(), {0})
+    End Sub
+
+    Private Function GetFilter() As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean))
+      Return Function(x) x.IntColumn <= 3
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Tests/TestSelectSortProvider.vb
+++ b/Source/Test/Yamo.Test/Tests/TestSelectSortProvider.vb
@@ -1,0 +1,24 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo
+Imports Yamo.Expressions.Builders
+Imports Yamo.Test.Model
+
+Namespace Tests
+
+  Public Class TestSelectSortProvider
+    Implements ISelectSortProvider
+
+    Public Sub AddOrderBy(Of T)(builder As SelectSqlExpressionBuilder) Implements ISelectSortProvider.AddOrderBy
+      If GetType(T) IsNot GetType(Label) Then
+        Throw New NotSupportedException
+      End If
+
+      builder.AddOrderBy(GetOrderBy(), {0}, True)
+    End Sub
+
+    Private Function GetOrderBy() As Expression(Of Func(Of Label, String))
+      Return Function(x) x.Description
+    End Function
+
+  End Class
+End Namespace


### PR DESCRIPTION
This PR adds new possibility to define filter and sort clauses in `SELECT` statements.

Normally, you would build an SQL expression using Yamo fluent syntax. However, there are some (advanced) scenarios, where this might be a bit cumbersome. For example if you need to convert a special filter object (e.g. [grid’s filter criteria](https://docs.devexpress.com/WPF/DevExpress.Xpf.Grid.DataControlBase.FilterCriteria)) to SQL expression.

There are now `Where`, `And`, `OrderBy`, `ThenBy` overloads that accept filter and sort providers. 

Providers are simple interfaces:
```cs
public interface ISelectFilterProvider
{
    void AddWhere<T>(SelectSqlExpressionBuilder builder);
}
```

```cs
public interface ISelectSortProvider
{
    void AddOrderBy<T>(SelectSqlExpressionBuilder builder);
}
```

In your implementation of `AddWhere` and `AddOrderBy` methods use provided `SelectSqlExpressionBuilder` instance to add parts to the `WHERE` and `ORDER BY` clauses. To do so, call `AddWhere` and `AddOrderBy` methods of the builder.

Generic type `T` depends on whether there are any joins in your query. If not, `T` will be equal to the type of your queried entity. If there are multiple joined tables, `T` will equal to the `Join<T1, T2>`, `Join<T1, T2, T3>`, ... (depending on how many joined tables there are). Depending on your use case, you might need to know `T` to create proper `ParameterExpression` value for your filter/sort lambda expressions.