### PR TITLE
Added support for entities initialization

### DIFF
--- a/Source/Source/Yamo/IInitializable.vb
+++ b/Source/Source/Yamo/IInitializable.vb
@@ -1,0 +1,11 @@
+﻿''' <summary>
+''' Interface for model entities that requires initialization after creation.
+''' </summary>
+Public Interface IInitializable
+
+  ''' <summary>
+  ''' Initializes the instance. Called after entity creation.
+  ''' </summary>
+  Sub Initialize()
+
+End Interface

--- a/Source/Source/Yamo/Internal/Query/QueryExecutor.vb
+++ b/Source/Source/Yamo/Internal/Query/QueryExecutor.vb
@@ -226,11 +226,13 @@ Namespace Internal.Query
             If readerData.ContainsNonNullColumnCheck Then
               If SqlResultReader.ContainsNonNullColumn(dataReader, readerData.ReaderIndex, sqlResult.GetColumnCount()) Then
                 value = DirectCast(reader(dataReader, readerData), T)
+                ' NOTE - Initialize is called in the reader
                 ' NOTE - ResetDbPropertyModifiedTracking is called in the reader
               End If
 
             Else
               value = DirectCast(reader(dataReader, readerData), T)
+              ' NOTE - Initialize is called in the reader
               ' NOTE - ResetDbPropertyModifiedTracking is called in the reader
             End If
 
@@ -290,6 +292,7 @@ Namespace Internal.Query
               value = DirectCast(reader(dataReader, readerData.ReaderData), T)
             End If
 
+            Initialize(value)
             FillIncluded(readerData, dataReaderType, dataReader, value)
             ResetDbPropertyModifiedTracking(value)
           End If
@@ -400,6 +403,7 @@ Namespace Internal.Query
             While dataReader.Read()
               If SqlResultReader.ContainsNonNullColumn(dataReader, readerData.ReaderIndex, sqlResult.GetColumnCount()) Then
                 Dim value = DirectCast(reader(dataReader, readerData), T)
+                ' NOTE - Initialize is called in the reader
                 ' NOTE - ResetDbPropertyModifiedTracking is called in the reader
                 values.Add(value)
               Else
@@ -410,6 +414,7 @@ Namespace Internal.Query
           Else
             While dataReader.Read()
               Dim value = DirectCast(reader(dataReader, readerData), T)
+              ' NOTE - Initialize is called in the reader
               ' NOTE - ResetDbPropertyModifiedTracking is called in the reader
               values.Add(value)
             End While
@@ -448,6 +453,7 @@ Namespace Internal.Query
               While dataReader.Read()
                 If containsPKReader(dataReader, entitySqlResultReaderData.ReaderIndex, entitySqlResultReaderData.PKOffsets) Then
                   Dim value = DirectCast(reader(dataReader, 0, includedColumns), T)
+                  Initialize(value)
                   FillIncluded(readerData, dataReaderType, dataReader, value)
                   ResetDbPropertyModifiedTracking(value)
                   values.Add(value)
@@ -460,6 +466,7 @@ Namespace Internal.Query
               ' record should always be present, so we can skip PK check
               While dataReader.Read()
                 Dim value = DirectCast(reader(dataReader, 0, includedColumns), T)
+                Initialize(value)
                 FillIncluded(readerData, dataReaderType, dataReader, value)
                 ResetDbPropertyModifiedTracking(value)
                 values.Add(value)
@@ -474,6 +481,7 @@ Namespace Internal.Query
               While dataReader.Read()
                 If SqlResultReader.ContainsNonNullColumn(dataReader, readerData.ReaderData.ReaderIndex, sqlResult.GetColumnCount()) Then
                   Dim value = DirectCast(reader(dataReader, readerData.ReaderData), T)
+                  Initialize(value)
                   FillIncluded(readerData, dataReaderType, dataReader, value)
                   ResetDbPropertyModifiedTracking(value)
                   values.Add(value)
@@ -485,6 +493,7 @@ Namespace Internal.Query
             Else
               While dataReader.Read()
                 Dim value = DirectCast(reader(dataReader, readerData.ReaderData), T)
+                Initialize(value)
                 FillIncluded(readerData, dataReaderType, dataReader, value)
                 ResetDbPropertyModifiedTracking(value)
                 values.Add(value)
@@ -617,6 +626,8 @@ Namespace Internal.Query
         End If
       End If
 
+      Initialize(value)
+
       FillRelationships(readerData, declaringEntity, value)
       FillIncluded(readerData, dataReaderType, dataReader, value)
 
@@ -671,7 +682,10 @@ Namespace Internal.Query
 
           value = entitySqlResultReaderData.Reader(dataReader, entitySqlResultReaderData.ReaderIndex, entitySqlResultReaderData.Entity.IncludedColumns)
 
+          Initialize(value)
+
           cache.AddValue(entityIndex, key, value)
+
           FillRelationships(readerData, declaringEntity, value)
           FillIncluded(readerData, dataReaderType, dataReader, value)
         End If
@@ -694,6 +708,8 @@ Namespace Internal.Query
           Return Nothing
         End If
 
+        Initialize(value)
+
         FillRelationships(readerData, declaringEntity, value)
         FillIncluded(readerData, dataReaderType, dataReader, value)
       End If
@@ -713,6 +729,16 @@ Namespace Internal.Query
         Return value
       End If
     End Function
+
+    ''' <summary>
+    ''' Initialize entity if it implements <see cref="IInitializable"/>.
+    ''' </summary>
+    ''' <param name="obj"></param>
+    Private Sub Initialize(obj As Object)
+      If TypeOf obj Is IInitializable Then
+        DirectCast(obj, IInitializable).Initialize()
+      End If
+    End Sub
 
     ''' <summary>
     ''' Resets database property modified tracking on an entity if it implements <see cref="IHasDbPropertyModifiedTracking"/>.

--- a/Source/Test/Yamo.Test.SQLite/Sql/SQLiteDbInitialize.sql
+++ b/Source/Test/Yamo.Test.SQLite/Sql/SQLiteDbInitialize.sql
@@ -23,6 +23,20 @@ CREATE TABLE [LabelArchive] (
 
 
 
+CREATE TABLE [ItemWithInitialization] (
+  [Id] INTEGER  NOT NULL
+, [Description] nvarchar(50)  NOT NULL
+, CONSTRAINT [PK_ItemWithInitialization] PRIMARY KEY ([Id])
+);
+
+CREATE TABLE [ItemWithInitializationArchive] (
+  [Id] INTEGER  NOT NULL
+, [Description] nvarchar(50)  NOT NULL
+, CONSTRAINT [PK_ItemWithInitializationArchive] PRIMARY KEY ([Id])
+);
+
+
+
 CREATE TABLE [ItemWithPropertyModifiedTracking] (
   [Id] INTEGER  NOT NULL
 , [Description] nvarchar(50)  NOT NULL

--- a/Source/Test/Yamo.Test.SQLite/Sql/SQLiteDbUninitialize.sql
+++ b/Source/Test/Yamo.Test.SQLite/Sql/SQLiteDbUninitialize.sql
@@ -20,6 +20,8 @@ DROP TABLE IF EXISTS ItemWithIdentityIdAndDefaultValues;
 DROP TABLE IF EXISTS ItemWithIdentityIdAndDefaultValuesArchive;
 DROP TABLE IF EXISTS ItemWithOnlySQLiteSupportedFields;
 DROP TABLE IF EXISTS ItemWithOnlySQLiteSupportedFieldsArchive;
+DROP TABLE IF EXISTS ItemWithInitialization;
+DROP TABLE IF EXISTS ItemWithInitializationArchive;
 DROP TABLE IF EXISTS ItemWithPropertyModifiedTracking;
 DROP TABLE IF EXISTS ItemWithPropertyModifiedTrackingArchive;
 DROP TABLE IF EXISTS Label;

--- a/Source/Test/Yamo.Test.SQLite/Tests/InitializableTests.vb
+++ b/Source/Test/Yamo.Test.SQLite/Tests/InitializableTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class InitializableTests
+    Inherits Yamo.Test.Tests.InitializableTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SQLiteTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test.SqlServer/Sql/SqlServerDbInitialize.sql
+++ b/Source/Test/Yamo.Test.SqlServer/Sql/SqlServerDbInitialize.sql
@@ -298,6 +298,26 @@ CREATE TABLE [dbo].[ItemWithIdentityIdAndDefaultValuesArchive](
 
 
 
+CREATE TABLE [dbo].[ItemWithInitialization](
+	[Id] [int] IDENTITY(1,1) NOT NULL,
+	[Description] [nvarchar](50) NOT NULL,
+ CONSTRAINT [PK_ItemWithInitialization] PRIMARY KEY CLUSTERED 
+(
+	[Id] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+
+CREATE TABLE [dbo].[ItemWithInitializationArchive](
+	[Id] [int] IDENTITY(1,1) NOT NULL,
+	[Description] [nvarchar](50) NOT NULL,
+ CONSTRAINT [PK_ItemWithInitializationArchive] PRIMARY KEY CLUSTERED 
+(
+	[Id] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+
+
+
 CREATE TABLE [dbo].[ItemWithPropertyModifiedTracking](
 	[Id] [int] IDENTITY(1,1) NOT NULL,
 	[Description] [nvarchar](50) NOT NULL,

--- a/Source/Test/Yamo.Test.SqlServer/Tests/InitializableTests.vb
+++ b/Source/Test/Yamo.Test.SqlServer/Tests/InitializableTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class InitializableTests
+    Inherits Yamo.Test.Tests.InitializableTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SqlServerTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/BaseTestDbContext.vb
+++ b/Source/Test/Yamo.Test/BaseTestDbContext.vb
@@ -30,6 +30,8 @@ Public Class BaseTestDbContext
     CreateItemWithIdentityIdArchiveModel(modelBuilder)
     CreateItemWithIdentityIdAndDefaultValuesModel(modelBuilder)
     CreateItemWithIdentityIdAndDefaultValuesArchiveModel(modelBuilder)
+    CreateItemWithInitializationModel(modelBuilder)
+    CreateItemWithInitializationArchiveModel(modelBuilder)
     CreateItemWithPropertyModifiedTrackingModel(modelBuilder)
     CreateItemWithPropertyModifiedTrackingArchiveModel(modelBuilder)
     CreateLabelModel(modelBuilder)
@@ -252,6 +254,20 @@ Public Class BaseTestDbContext
     modelBuilder.Entity(Of ItemWithIdentityIdAndDefaultValuesArchive).Property(Function(x) x.Description).IsRequired()
     modelBuilder.Entity(Of ItemWithIdentityIdAndDefaultValuesArchive).Property(Function(x) x.UniqueidentifierValue).HasDefaultValue()
     modelBuilder.Entity(Of ItemWithIdentityIdAndDefaultValuesArchive).Property(Function(x) x.IntValue).HasDefaultValue()
+  End Sub
+
+  Private Sub CreateItemWithInitializationModel(modelBuilder As ModelBuilder)
+    modelBuilder.Entity(Of ItemWithInitialization)()
+
+    modelBuilder.Entity(Of ItemWithInitialization).Property(Function(x) x.Id).IsKey().IsIdentity()
+    modelBuilder.Entity(Of ItemWithInitialization).Property(Function(x) x.Description).IsRequired()
+  End Sub
+
+  Private Sub CreateItemWithInitializationArchiveModel(modelBuilder As ModelBuilder)
+    modelBuilder.Entity(Of ItemWithInitializationArchive)()
+
+    modelBuilder.Entity(Of ItemWithInitializationArchive).Property(Function(x) x.Id).IsKey().IsIdentity()
+    modelBuilder.Entity(Of ItemWithInitializationArchive).Property(Function(x) x.Description).IsRequired()
   End Sub
 
   Private Sub CreateItemWithPropertyModifiedTrackingModel(modelBuilder As ModelBuilder)

--- a/Source/Test/Yamo.Test/Model/ItemWithInitialization.vb
+++ b/Source/Test/Yamo.Test/Model/ItemWithInitialization.vb
@@ -1,11 +1,11 @@
 ﻿Namespace Model
 
-  Public Class NonModelObjectWithInitialization
+  Public Class ItemWithInitialization
     Implements IInitializable
 
-    Public Property IntValue As Int32
+    Public Property Id As Int32
 
-    Public Property StringValue As String
+    Public Property Description As String
 
     Private m_IsInitialized As Boolean = False
     Public ReadOnly Property IsInitialized As Boolean
@@ -15,23 +15,27 @@
     End Property
 
     Public Overrides Function Equals(obj As Object) As Boolean
-      If obj Is Nothing OrElse TypeOf obj IsNot NonModelObjectWithInitialization Then
+      If obj Is Nothing OrElse TypeOf obj IsNot ItemWithInitialization Then
         Return False
       Else
-        Dim o = DirectCast(obj, NonModelObjectWithInitialization)
+        Dim o = DirectCast(obj, ItemWithInitialization)
 
-        If Not Object.Equals(Me.IntValue, o.IntValue) Then Return False
-        If Not Object.Equals(Me.StringValue, o.StringValue) Then Return False
+        If Not Object.Equals(Me.Id, o.Id) Then Return False
+        If Not Object.Equals(Me.Description, o.Description) Then Return False
 
         Return True
       End If
     End Function
 
     Public Overrides Function GetHashCode() As Int32
-      Return HashCode.Combine(Me.IntValue, Me.StringValue)
+      Return HashCode.Combine(Me.Id, Me.Description)
     End Function
 
     Public Sub Initialize() Implements IInitializable.Initialize
+      If m_IsInitialized Then
+        Throw New InvalidOperationException("Already initialized.")
+      End If
+
       m_IsInitialized = True
     End Sub
 

--- a/Source/Test/Yamo.Test/Model/ItemWithInitializationArchive.vb
+++ b/Source/Test/Yamo.Test/Model/ItemWithInitializationArchive.vb
@@ -1,0 +1,7 @@
+﻿Namespace Model
+
+  Public Class ItemWithInitializationArchive
+    Inherits ItemWithInitialization
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Model/ModelFactory.vb
+++ b/Source/Test/Yamo.Test/Model/ModelFactory.vb
@@ -225,6 +225,12 @@
       }
     End Function
 
+    Public Overridable Function CreateItemWithInitialization() As ItemWithInitialization
+      Return New ItemWithInitialization With {
+        .Description = Helpers.Data.CreateRandomString(50)
+      }
+    End Function
+
     Public Overridable Function CreateItemWithPropertyModifiedTracking() As ItemWithPropertyModifiedTracking
       Return New ItemWithPropertyModifiedTracking With {
         .Description = Helpers.Data.CreateRandomString(50),

--- a/Source/Test/Yamo.Test/Model/NonModelObjectWithInitialization.vb
+++ b/Source/Test/Yamo.Test/Model/NonModelObjectWithInitialization.vb
@@ -1,0 +1,50 @@
+﻿Namespace Model
+
+  Public Class NonModelObjectWithPropertyModifiedTracking
+    Inherits PropertyModifiedTrackingBase
+
+    Private m_IntValue As Int32
+    Public Property IntValue() As Int32
+      Get
+        Return m_IntValue
+      End Get
+      Set(ByVal value As Int32)
+        If Not m_IntValue = value Then
+          m_IntValue = value
+          MarkPropertyAsModified(NameOf(Me.IntValue))
+        End If
+      End Set
+    End Property
+
+    Private m_StringValue As String
+    Public Property StringValue() As String
+      Get
+        Return m_StringValue
+      End Get
+      Set(ByVal value As String)
+        If Not String.Equals(m_StringValue, value) Then
+          m_StringValue = value
+          MarkPropertyAsModified(NameOf(Me.StringValue))
+        End If
+      End Set
+    End Property
+
+    Public Overrides Function Equals(obj As Object) As Boolean
+      If obj Is Nothing OrElse TypeOf obj IsNot NonModelObjectWithPropertyModifiedTracking Then
+        Return False
+      Else
+        Dim o = DirectCast(obj, NonModelObjectWithPropertyModifiedTracking)
+
+        If Not Object.Equals(Me.IntValue, o.IntValue) Then Return False
+        If Not Object.Equals(Me.StringValue, o.StringValue) Then Return False
+
+        Return True
+      End If
+    End Function
+
+    Public Overrides Function GetHashCode() As Int32
+      Return HashCode.Combine(Me.IntValue, Me.StringValue)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Tests/InitializableTests.vb
+++ b/Source/Test/Yamo.Test/Tests/InitializableTests.vb
@@ -1,0 +1,284 @@
+﻿Imports Yamo.Test.Model
+
+Namespace Tests
+
+  Public MustInherit Class InitializableTests
+    Inherits BaseIntegrationTests
+
+    Protected Const ItemWithInitializationArchiveTableName As String = "ItemWithInitializationArchive"
+
+    <TestMethod()>
+    Public Overridable Sub SelectRecordWithInitialization()
+      Dim item1 = Me.ModelFactory.CreateItemWithInitialization()
+      Dim item2 = Me.ModelFactory.CreateItemWithInitialization()
+      Dim item3 = Me.ModelFactory.CreateItemWithInitialization()
+
+      Using db = CreateDbContext()
+        db.Insert(item1)
+        db.Insert(item2)
+        db.Insert(item3)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result1 = db.From(Of ItemWithInitialization).SelectAll().ToList()
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) x.IsInitialized))
+
+        Dim result2 = db.From(Of ItemWithInitialization).SelectAll().FirstOrDefault()
+        Assert.IsTrue(result2.IsInitialized)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectRecordWithInitializationFromJoinedTable()
+      Dim linkedItem1 = Me.ModelFactory.CreateLinkedItem(1, Nothing)
+      Dim linkedItem2 = Me.ModelFactory.CreateLinkedItem(2, Nothing)
+      Dim linkedItem3 = Me.ModelFactory.CreateLinkedItem(3, Nothing)
+
+      InsertItems(linkedItem1, linkedItem2, linkedItem3)
+
+      Dim item1 = Me.ModelFactory.CreateItemWithInitialization()
+      item1.Id = 1
+      Dim item2 = Me.ModelFactory.CreateItemWithInitialization()
+      item2.Id = 2
+      Dim item3 = Me.ModelFactory.CreateItemWithInitialization()
+      item3.Id = 3
+
+      Using db = CreateDbContext()
+        db.Insert(item1, useDbIdentityAndDefaults:=False)
+        db.Insert(item2, useDbIdentityAndDefaults:=False)
+        db.Insert(item3, useDbIdentityAndDefaults:=False)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result1 = db.From(Of LinkedItem).
+                         Join(Of ItemWithInitialization)(Function(j) j.T1.Id = j.T2.Id).As(Function(x) x.RelatedItem).
+                         SelectAll().ToList()
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) DirectCast(x.RelatedItem, ItemWithInitialization).IsInitialized))
+
+        Dim result2 = db.From(Of LinkedItem).
+                         Join(Of ItemWithInitialization)(Function(j) j.T1.Id = j.T2.Id).As(Function(x) x.RelatedItem).
+                         SelectAll().FirstOrDefault()
+        Assert.IsTrue(DirectCast(result2.RelatedItem, ItemWithInitialization).IsInitialized)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectModelEntityRecordWithInitializationFromFromSubquery()
+      Dim item1 = Me.ModelFactory.CreateItemWithInitialization()
+      Dim item2 = Me.ModelFactory.CreateItemWithInitialization()
+      Dim item3 = Me.ModelFactory.CreateItemWithInitialization()
+
+      InsertItems(item1, item2, item3)
+
+      Using db = CreateDbContext()
+        Dim result1 = db.From(Function(c)
+                                Return c.From(Of ItemWithInitialization).
+                                        SelectAll()
+                              End Function).
+                         SelectAll().ToList()
+
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) x.IsInitialized))
+
+        Dim result2 = db.From(Function(c)
+                                Return c.From(Of ItemWithInitialization).
+                                        SelectAll()
+                              End Function).
+                         SelectAll().FirstOrDefault()
+
+        Assert.IsTrue(result2.IsInitialized)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectNonModelAdHocTypeRecordWithInitializationFromFromSubquery()
+      Dim item1 = Me.ModelFactory.CreateItemWithInitialization()
+      Dim item2 = Me.ModelFactory.CreateItemWithInitialization()
+      Dim item3 = Me.ModelFactory.CreateItemWithInitialization()
+
+      InsertItems(item1, item2, item3)
+
+      Using db = CreateDbContext()
+        Dim result1 = db.From(Function(c)
+                                Return c.From(Of ItemWithInitialization).
+                                        Select(Function(x) New NonModelObjectWithInitialization With {.IntValue = x.Id, .StringValue = x.Description})
+                              End Function).
+                         SelectAll().ToList()
+
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) x.IsInitialized))
+
+        Dim result2 = db.From(Function(c)
+                                Return c.From(Of ItemWithInitialization).
+                                        Select(Function(x) New NonModelObjectWithInitialization With {.IntValue = x.Id, .StringValue = x.Description})
+                              End Function).
+                         SelectAll().FirstOrDefault()
+
+        Assert.IsTrue(result2.IsInitialized)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectModelEntityRecordWithInitializationFromJoinSubquery()
+      Dim linkedItem1 = Me.ModelFactory.CreateLinkedItem(1, Nothing)
+      Dim linkedItem2 = Me.ModelFactory.CreateLinkedItem(2, Nothing)
+      Dim linkedItem3 = Me.ModelFactory.CreateLinkedItem(3, Nothing)
+
+      InsertItems(linkedItem1, linkedItem2, linkedItem3)
+
+      Dim item1 = Me.ModelFactory.CreateItemWithInitialization()
+      item1.Id = 1
+      Dim item2 = Me.ModelFactory.CreateItemWithInitialization()
+      item2.Id = 2
+      Dim item3 = Me.ModelFactory.CreateItemWithInitialization()
+      item3.Id = 3
+
+      Using db = CreateDbContext()
+        db.Insert(item1, useDbIdentityAndDefaults:=False)
+        db.Insert(item2, useDbIdentityAndDefaults:=False)
+        db.Insert(item3, useDbIdentityAndDefaults:=False)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result1 = db.From(Of LinkedItem).
+                         Join(Function(c)
+                                Return c.From(Of ItemWithInitialization).
+                                         SelectAll()
+                              End Function).
+                         On(Function(j) j.T1.Id = j.T2.Id).As(Function(x) x.RelatedItem).
+                         SelectAll().ToList()
+
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) DirectCast(x.RelatedItem, ItemWithInitialization).IsInitialized))
+
+        Dim result2 = db.From(Of LinkedItem).
+                         Join(Function(c)
+                                Return c.From(Of ItemWithInitialization).
+                                         SelectAll()
+                              End Function).
+                         On(Function(j) j.T1.Id = j.T2.Id).As(Function(x) x.RelatedItem).
+                         SelectAll().FirstOrDefault()
+
+        Assert.IsTrue(DirectCast(result2.RelatedItem, ItemWithInitialization).IsInitialized)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectNonModelAdHocTypeRecordWithInitializationFromJoinSubquery()
+      Dim linkedItem1 = Me.ModelFactory.CreateLinkedItem(1, Nothing)
+      Dim linkedItem2 = Me.ModelFactory.CreateLinkedItem(2, Nothing)
+      Dim linkedItem3 = Me.ModelFactory.CreateLinkedItem(3, Nothing)
+
+      InsertItems(linkedItem1, linkedItem2, linkedItem3)
+
+      Dim item1 = Me.ModelFactory.CreateItemWithInitialization()
+      item1.Id = 1
+      Dim item2 = Me.ModelFactory.CreateItemWithInitialization()
+      item2.Id = 2
+      Dim item3 = Me.ModelFactory.CreateItemWithInitialization()
+      item3.Id = 3
+
+      Using db = CreateDbContext()
+        db.Insert(item1, useDbIdentityAndDefaults:=False)
+        db.Insert(item2, useDbIdentityAndDefaults:=False)
+        db.Insert(item3, useDbIdentityAndDefaults:=False)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result1 = db.From(Of LinkedItem).
+                         Join(Function(c)
+                                Return c.From(Of ItemWithInitialization).
+                                         Select(Function(x) New NonModelObjectWithInitialization With {.IntValue = x.Id, .StringValue = x.Description})
+                              End Function).
+                         On(Function(j) j.T1.Id = j.T2.IntValue).As(Function(x) x.RelatedItem).
+                         SelectAll().ToList()
+
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) DirectCast(x.RelatedItem, NonModelObjectWithInitialization).IsInitialized))
+
+        Dim result2 = db.From(Of LinkedItem).
+                         Join(Function(c)
+                                Return c.From(Of ItemWithInitialization).
+                                         Select(Function(x) New NonModelObjectWithInitialization With {.IntValue = x.Id, .StringValue = x.Description})
+                              End Function).
+                         On(Function(j) j.T1.Id = j.T2.IntValue).As(Function(x) x.RelatedItem).
+                         SelectAll().FirstOrDefault()
+
+        Assert.IsTrue(DirectCast(result2.RelatedItem, NonModelObjectWithInitialization).IsInitialized)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub CustomSelectOfRecordWithInitialization()
+      Dim item1 = Me.ModelFactory.CreateItemWithInitialization()
+      Dim item2 = Me.ModelFactory.CreateItemWithInitialization()
+      Dim item3 = Me.ModelFactory.CreateItemWithInitialization()
+
+      Using db = CreateDbContext()
+        db.Insert(item1)
+        db.Insert(item2)
+        db.Insert(item3)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result1 = db.From(Of ItemWithInitialization).
+                         Select(Function(x) x).
+                         ToList()
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) x.IsInitialized))
+
+        Dim result2 = db.From(Of ItemWithInitialization).
+                         Select(Function(x) x).
+                         FirstOrDefault()
+        Assert.IsTrue(result2.IsInitialized)
+
+        Dim result3 = db.From(Of ItemWithInitialization).
+                         Select(Function(x) (x.Id, Entity:=x)).
+                         ToList()
+        Assert.AreEqual(3, result3.Count)
+        Assert.IsTrue(result3.All(Function(x) x.Entity.IsInitialized))
+
+        Dim result4 = db.From(Of ItemWithInitialization).
+                         Select(Function(x) (x.Id, Entity:=x)).
+                         FirstOrDefault()
+        Assert.IsTrue(result4.Entity.IsInitialized)
+
+        Dim result5 = db.From(Of ItemWithInitialization).
+                         Select(Function(x) New With {x.Id, .Entity = x}).
+                         ToList()
+        Assert.AreEqual(3, result5.Count)
+        Assert.IsTrue(result5.All(Function(x) x.Entity.IsInitialized))
+
+        Dim result6 = db.From(Of ItemWithInitialization).
+                         Select(Function(x) New With {x.Id, .Entity = x}).
+                         FirstOrDefault()
+        Assert.IsTrue(result6.Entity.IsInitialized)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub QueryModelEntityRecordWithInitialization()
+      Dim item1 = Me.ModelFactory.CreateItemWithInitialization()
+      Dim item2 = Me.ModelFactory.CreateItemWithInitialization()
+      Dim item3 = Me.ModelFactory.CreateItemWithInitialization()
+
+      Using db = CreateDbContext()
+        db.Insert(item1)
+        db.Insert(item2)
+        db.Insert(item3)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result1 = db.Query(Of ItemWithInitialization)($"SELECT {Sql.Model.Columns(Of ItemWithInitialization)} FROM ItemWithInitialization ORDER BY Id")
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) x.IsInitialized))
+
+        Dim result2 = db.QueryFirstOrDefault(Of ItemWithInitialization)($"SELECT {Sql.Model.Columns(Of ItemWithInitialization)} FROM ItemWithInitialization ORDER BY Id")
+        Assert.IsTrue(result2.IsInitialized)
+      End Using
+    End Sub
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Tests/PropertyModifiedTrackingTests.vb
+++ b/Source/Test/Yamo.Test/Tests/PropertyModifiedTrackingTests.vb
@@ -208,9 +208,12 @@ Namespace Tests
       End Using
 
       Using db = CreateDbContext()
-        Dim result = db.From(Of ItemWithPropertyModifiedTracking).SelectAll().ToList()
-        Assert.AreEqual(3, result.Count)
-        Assert.IsTrue(result.All(Function(x) Not x.IsAnyDbPropertyModified()))
+        Dim result1 = db.From(Of ItemWithPropertyModifiedTracking).SelectAll().ToList()
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) Not x.IsAnyDbPropertyModified()))
+
+        Dim result2 = db.From(Of ItemWithPropertyModifiedTracking).SelectAll().FirstOrDefault()
+        Assert.IsTrue(Not result2.IsAnyDbPropertyModified())
       End Using
     End Sub
 
@@ -236,11 +239,16 @@ Namespace Tests
       End Using
 
       Using db = CreateDbContext()
-        Dim result = db.From(Of LinkedItem).
-                        Join(Of ItemWithPropertyModifiedTracking)(Function(j) j.T1.Id = j.T2.Id).As(Function(x) x.RelatedItem).
-                        SelectAll().ToList()
-        Assert.AreEqual(3, result.Count)
-        Assert.IsTrue(result.All(Function(x) Not DirectCast(x.RelatedItem, ItemWithPropertyModifiedTracking).IsAnyDbPropertyModified()))
+        Dim result1 = db.From(Of LinkedItem).
+                         Join(Of ItemWithPropertyModifiedTracking)(Function(j) j.T1.Id = j.T2.Id).As(Function(x) x.RelatedItem).
+                         SelectAll().ToList()
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) Not DirectCast(x.RelatedItem, ItemWithPropertyModifiedTracking).IsAnyDbPropertyModified()))
+
+        Dim result2 = db.From(Of LinkedItem).
+                         Join(Of ItemWithPropertyModifiedTracking)(Function(j) j.T1.Id = j.T2.Id).As(Function(x) x.RelatedItem).
+                         SelectAll().FirstOrDefault()
+        Assert.IsTrue(Not DirectCast(result2.RelatedItem, ItemWithPropertyModifiedTracking).IsAnyDbPropertyModified())
       End Using
     End Sub
 
@@ -253,14 +261,22 @@ Namespace Tests
       InsertItems(item1, item2, item3)
 
       Using db = CreateDbContext()
-        Dim result = db.From(Function(c)
-                               Return c.From(Of ItemWithPropertyModifiedTracking).
+        Dim result1 = db.From(Function(c)
+                                Return c.From(Of ItemWithPropertyModifiedTracking).
                                         SelectAll()
-                             End Function).
-                        SelectAll().ToList()
+                              End Function).
+                         SelectAll().ToList()
 
-        Assert.AreEqual(3, result.Count)
-        Assert.IsTrue(result.All(Function(x) Not x.IsAnyDbPropertyModified()))
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) Not x.IsAnyDbPropertyModified()))
+
+        Dim result2 = db.From(Function(c)
+                                Return c.From(Of ItemWithPropertyModifiedTracking).
+                                        SelectAll()
+                              End Function).
+                         SelectAll().FirstOrDefault()
+
+        Assert.IsTrue(Not result2.IsAnyDbPropertyModified())
       End Using
     End Sub
 
@@ -273,14 +289,22 @@ Namespace Tests
       InsertItems(item1, item2, item3)
 
       Using db = CreateDbContext()
-        Dim result = db.From(Function(c)
-                               Return c.From(Of ItemWithPropertyModifiedTracking).
+        Dim result1 = db.From(Function(c)
+                                Return c.From(Of ItemWithPropertyModifiedTracking).
                                         Select(Function(x) New NonModelObjectWithPropertyModifiedTracking With {.IntValue = x.Id, .StringValue = x.Description})
-                             End Function).
-                        SelectAll().ToList()
+                              End Function).
+                         SelectAll().ToList()
 
-        Assert.AreEqual(3, result.Count)
-        Assert.IsTrue(result.All(Function(x) Not x.IsAnyDbPropertyModified()))
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) Not x.IsAnyDbPropertyModified()))
+
+        Dim result2 = db.From(Function(c)
+                                Return c.From(Of ItemWithPropertyModifiedTracking).
+                                        Select(Function(x) New NonModelObjectWithPropertyModifiedTracking With {.IntValue = x.Id, .StringValue = x.Description})
+                              End Function).
+                         SelectAll().FirstOrDefault()
+
+        Assert.IsTrue(Not result2.IsAnyDbPropertyModified())
       End Using
     End Sub
 
@@ -306,16 +330,26 @@ Namespace Tests
       End Using
 
       Using db = CreateDbContext()
-        Dim result = db.From(Of LinkedItem).
-                        Join(Function(c)
-                               Return c.From(Of ItemWithPropertyModifiedTracking).
-                                        SelectAll()
-                             End Function).
-                        On(Function(j) j.T1.Id = j.T2.Id).As(Function(x) x.RelatedItem).
-                        SelectAll().ToList()
+        Dim result1 = db.From(Of LinkedItem).
+                         Join(Function(c)
+                                Return c.From(Of ItemWithPropertyModifiedTracking).
+                                         SelectAll()
+                              End Function).
+                         On(Function(j) j.T1.Id = j.T2.Id).As(Function(x) x.RelatedItem).
+                         SelectAll().ToList()
 
-        Assert.AreEqual(3, result.Count)
-        Assert.IsTrue(result.All(Function(x) Not DirectCast(x.RelatedItem, ItemWithPropertyModifiedTracking).IsAnyDbPropertyModified()))
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) Not DirectCast(x.RelatedItem, ItemWithPropertyModifiedTracking).IsAnyDbPropertyModified()))
+
+        Dim result2 = db.From(Of LinkedItem).
+                         Join(Function(c)
+                                Return c.From(Of ItemWithPropertyModifiedTracking).
+                                         SelectAll()
+                              End Function).
+                         On(Function(j) j.T1.Id = j.T2.Id).As(Function(x) x.RelatedItem).
+                         SelectAll().FirstOrDefault()
+
+        Assert.IsTrue(Not DirectCast(result2.RelatedItem, ItemWithPropertyModifiedTracking).IsAnyDbPropertyModified())
       End Using
     End Sub
 
@@ -341,16 +375,26 @@ Namespace Tests
       End Using
 
       Using db = CreateDbContext()
-        Dim result = db.From(Of LinkedItem).
-                        Join(Function(c)
-                               Return c.From(Of ItemWithPropertyModifiedTracking).
-                                        Select(Function(x) New NonModelObjectWithPropertyModifiedTracking With {.IntValue = x.Id, .StringValue = x.Description})
-                             End Function).
-                        On(Function(j) j.T1.Id = j.T2.IntValue).As(Function(x) x.RelatedItem).
-                        SelectAll().ToList()
+        Dim result1 = db.From(Of LinkedItem).
+                         Join(Function(c)
+                                Return c.From(Of ItemWithPropertyModifiedTracking).
+                                         Select(Function(x) New NonModelObjectWithPropertyModifiedTracking With {.IntValue = x.Id, .StringValue = x.Description})
+                              End Function).
+                         On(Function(j) j.T1.Id = j.T2.IntValue).As(Function(x) x.RelatedItem).
+                         SelectAll().ToList()
 
-        Assert.AreEqual(3, result.Count)
-        Assert.IsTrue(result.All(Function(x) Not DirectCast(x.RelatedItem, NonModelObjectWithPropertyModifiedTracking).IsAnyDbPropertyModified()))
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) Not DirectCast(x.RelatedItem, NonModelObjectWithPropertyModifiedTracking).IsAnyDbPropertyModified()))
+
+        Dim result2 = db.From(Of LinkedItem).
+                         Join(Function(c)
+                                Return c.From(Of ItemWithPropertyModifiedTracking).
+                                         Select(Function(x) New NonModelObjectWithPropertyModifiedTracking With {.IntValue = x.Id, .StringValue = x.Description})
+                              End Function).
+                         On(Function(j) j.T1.Id = j.T2.IntValue).As(Function(x) x.RelatedItem).
+                         SelectAll().FirstOrDefault()
+
+        Assert.IsTrue(Not DirectCast(result2.RelatedItem, NonModelObjectWithPropertyModifiedTracking).IsAnyDbPropertyModified())
       End Using
     End Sub
 
@@ -368,22 +412,59 @@ Namespace Tests
 
       Using db = CreateDbContext()
         Dim result1 = db.From(Of ItemWithPropertyModifiedTracking).
-                        Select(Function(x) x).
-                        ToList()
+                         Select(Function(x) x).
+                         ToList()
         Assert.AreEqual(3, result1.Count)
         Assert.IsTrue(result1.All(Function(x) Not x.IsAnyDbPropertyModified()))
 
         Dim result2 = db.From(Of ItemWithPropertyModifiedTracking).
-                        Select(Function(x) (x.Id, Entity:=x)).
-                        ToList()
-        Assert.AreEqual(3, result2.Count)
-        Assert.IsTrue(result2.All(Function(x) Not x.Entity.IsAnyDbPropertyModified()))
+                         Select(Function(x) x).
+                         FirstOrDefault()
+        Assert.IsTrue(Not result2.IsAnyDbPropertyModified())
 
         Dim result3 = db.From(Of ItemWithPropertyModifiedTracking).
-                         Select(Function(x) New With {x.Id, .Entity = x}).
+                         Select(Function(x) (x.Id, Entity:=x)).
                          ToList()
         Assert.AreEqual(3, result3.Count)
         Assert.IsTrue(result3.All(Function(x) Not x.Entity.IsAnyDbPropertyModified()))
+
+        Dim result4 = db.From(Of ItemWithPropertyModifiedTracking).
+                         Select(Function(x) (x.Id, Entity:=x)).
+                         FirstOrDefault()
+        Assert.IsTrue(Not result4.Entity.IsAnyDbPropertyModified())
+
+        Dim result5 = db.From(Of ItemWithPropertyModifiedTracking).
+                         Select(Function(x) New With {x.Id, .Entity = x}).
+                         ToList()
+        Assert.AreEqual(3, result5.Count)
+        Assert.IsTrue(result5.All(Function(x) Not x.Entity.IsAnyDbPropertyModified()))
+
+        Dim result6 = db.From(Of ItemWithPropertyModifiedTracking).
+                         Select(Function(x) New With {x.Id, .Entity = x}).
+                         FirstOrDefault()
+        Assert.IsTrue(Not result6.Entity.IsAnyDbPropertyModified())
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub QueryModelEntityRecordWithPropertyModifiedTracking()
+      Dim item1 = Me.ModelFactory.CreateItemWithPropertyModifiedTracking()
+      Dim item2 = Me.ModelFactory.CreateItemWithPropertyModifiedTracking()
+      Dim item3 = Me.ModelFactory.CreateItemWithPropertyModifiedTracking()
+
+      Using db = CreateDbContext()
+        db.Insert(item1)
+        db.Insert(item2)
+        db.Insert(item3)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result1 = db.Query(Of ItemWithPropertyModifiedTracking)($"SELECT {Sql.Model.Columns(Of ItemWithPropertyModifiedTracking)} FROM ItemWithPropertyModifiedTracking ORDER BY Id")
+        Assert.AreEqual(3, result1.Count)
+        Assert.IsTrue(result1.All(Function(x) Not x.IsAnyDbPropertyModified()))
+
+        Dim result2 = db.QueryFirstOrDefault(Of ItemWithPropertyModifiedTracking)($"SELECT {Sql.Model.Columns(Of ItemWithPropertyModifiedTracking)} FROM ItemWithPropertyModifiedTracking ORDER BY Id")
+        Assert.IsTrue(Not result2.IsAnyDbPropertyModified())
       End Using
     End Sub
 


### PR DESCRIPTION
There is new `IInitializable` interface available:

```cs
public interface IInitializable
{
    void Initialize();
}
```
If entity implements this interface, `Initialize` method is called after object is created (when results of `SELECT` query are materialized).

Method is called after constructor and filling DB mapped properties. Relationship or included properties are set after the initialization.
