### PR TITLE
Added support for ternary conditional and null-coalescing operators

### DIFF
--- a/Source/Samples/Yamo.Playground.CS/Program.cs
+++ b/Source/Samples/Yamo.Playground.CS/Program.cs
@@ -21,8 +21,8 @@ namespace Yamo.Playground.CS
             m_Connection.Open();
 
             //Test1();
-            Test2();
-            Test2b();
+            //Test2();
+            //Test2b();
             //Test3();
             //Test4();
             //Test5();
@@ -86,7 +86,8 @@ namespace Yamo.Playground.CS
             //Test61();
             //Test62();
             //Test63();
-            Test64();
+            //Test64();
+            Test65();
         }
 
         public static MyContext CreateContext()
@@ -1310,6 +1311,25 @@ namespace Yamo.Playground.CS
                              .On(j => j.T1.Id == j.T2.ArticleId)
                              .Select(j => j.T2, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull)
                              .ToList();
+            }
+        }
+
+        public static void Test65()
+        {
+            using (var db = CreateContext())
+            {
+                var list = db.From<Blog>()
+                             .Select(x => x.ModifiedUserId.HasValue ? x.ModifiedUserId.Value : x.CreatedUserId)
+                             .ToList();
+
+            }
+
+            using (var db = CreateContext())
+            {
+                var list = db.From<Blog>()
+                             .Select(x => x.ModifiedUserId ?? x.CreatedUserId)
+                             .ToList();
+
             }
         }
 

--- a/Source/Source/Yamo/Internal/NodeInfo.vb
+++ b/Source/Source/Yamo/Internal/NodeInfo.vb
@@ -9,6 +9,8 @@ Namespace Internal
   ''' </summary>
   Public Class NodeInfo
 
+    ' TODO: SIP - is really IsCompare, IsCoalesce, IsConditional, ... necessary? Would't it be better to check it when needed (during boolean expansion)?.
+
     ''' <summary>
     ''' Gets node.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
@@ -36,6 +38,20 @@ Namespace Internal
     ''' </summary>
     ''' <returns></returns>
     Public Property IsCompare As Boolean
+
+    ''' <summary>
+    ''' Gets whether node represents coalesce operation (<see cref="ExpressionType.Coalesce"/>).<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Property IsCoalesce As Boolean
+
+    ''' <summary>
+    ''' Gets whether node represents conditional operation (<see cref="ExpressionType.Conditional"/>).<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Property IsConditional As Boolean
 
     ''' <summary>
     ''' Gets whether node represents <see cref="Nullable(Of T).Value"/> access.<br/>
@@ -82,6 +98,8 @@ Namespace Internal
       Me.IsNegation = False
       Me.IsIgnoredNegation = False
       Me.IsCompare = False
+      Me.IsCoalesce = False
+      Me.IsConditional = False
       Me.IsNullableValueAccess = False
       Me.IsNullableHasValueAccess = False
       Me.IsConvert = False

--- a/Source/Test/Yamo.Test/Tests/SelectWithWhereTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithWhereTests.vb
@@ -1258,6 +1258,106 @@ Namespace Tests
     End Sub
 
     <TestMethod()>
+    Public Overridable Sub SelectRecordUsingTernaryOperator()
+      Dim items = CreateItems()
+
+      items(0).IntColumn = 1
+      items(0).IntColumnNull = 42
+      items(0).BitColumn = False
+      items(0).BitColumnNull = True
+
+      items(1).IntColumn = 42
+      items(1).IntColumnNull = 20
+      items(1).BitColumn = True
+      items(1).BitColumnNull = False
+
+      items(2).IntColumn = 42
+      items(2).IntColumnNull = Nothing
+      items(2).BitColumn = True
+      items(2).BitColumnNull = Nothing
+
+      items(3).IntColumn = 4
+      items(3).IntColumnNull = 40
+      items(3).BitColumn = False
+      items(3).BitColumnNull = False
+
+      items(4).IntColumn = 42
+      items(4).IntColumnNull = Nothing
+      items(4).BitColumn = True
+      items(4).BitColumnNull = Nothing
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) If(x.IntColumnNull.HasValue, x.IntColumnNull.Value, x.IntColumn) = 42).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        CollectionAssert.AreEquivalent({items(0), items(2), items(4)}, result)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) If(x.BitColumnNull.HasValue, x.BitColumnNull.Value, x.BitColumn)).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        CollectionAssert.AreEquivalent({items(0), items(2), items(4)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectRecordUsingCoalesceOperator()
+      Dim items = CreateItems()
+
+      items(0).IntColumn = 1
+      items(0).IntColumnNull = 42
+      items(0).BitColumn = False
+      items(0).BitColumnNull = True
+
+      items(1).IntColumn = 42
+      items(1).IntColumnNull = 20
+      items(1).BitColumn = True
+      items(1).BitColumnNull = False
+
+      items(2).IntColumn = 42
+      items(2).IntColumnNull = Nothing
+      items(2).BitColumn = True
+      items(2).BitColumnNull = Nothing
+
+      items(3).IntColumn = 4
+      items(3).IntColumnNull = 40
+      items(3).BitColumn = False
+      items(3).BitColumnNull = False
+
+      items(4).IntColumn = 42
+      items(4).IntColumnNull = Nothing
+      items(4).BitColumn = True
+      items(4).BitColumnNull = Nothing
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) If(x.IntColumnNull, x.IntColumn) = 42).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        CollectionAssert.AreEquivalent({items(0), items(2), items(4)}, result)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) If(x.BitColumnNull, x.BitColumn)).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        CollectionAssert.AreEquivalent({items(0), items(2), items(4)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
     Public Overridable Sub SelectRecordByMultipleWhereConditions()
       Dim items = CreateItems()
 


### PR DESCRIPTION
Ternary conditional and null-coalescing operators can be now used when building SQL expression.

Ternary conditional operator translates to `CASE WHEN <condition> THEN <result1> ELSE <result2> END`:

```cs
using (var db = CreateContext())
{
    // SELECT CASE WHEN [T0].[ModifiedUserId] IS NOT NULL THEN [T0].[ModifiedUserId] ELSE [T0].[CreatedUserId] END [C0] FROM [Blog] [T0]
    var list = db.From<Blog>()
                 .Select(x => x.ModifiedUserId.HasValue ? x.ModifiedUserId.Value : x.CreatedUserId)
                 .ToList();
}
```

Null-coalescing operator translates to `COALESCE(<value1>, <value2>)`:
```cs
using (var db = CreateContext())
{
    // SELECT COALESCE([T0].[ModifiedUserId], [T0].[CreatedUserId]) [C0] FROM [Blog] [T0]
    var list = db.From<Blog>()
                 .Select(x => x.ModifiedUserId ?? x.CreatedUserId)
                 .ToList();
}
```