### PR TITLE
Added support for bitwise and shift operators

### DIFF
--- a/Source/Samples/Yamo.Playground.CS/Program.cs
+++ b/Source/Samples/Yamo.Playground.CS/Program.cs
@@ -87,7 +87,8 @@ namespace Yamo.Playground.CS
             //Test62();
             //Test63();
             //Test64();
-            Test65();
+            //Test65();
+            Test66();
         }
 
         public static MyContext CreateContext()
@@ -1297,7 +1298,7 @@ namespace Yamo.Playground.CS
                              .Include(j => j.T1.Tag, j => new { j.T2.Id, j.T2.Description }, NonModelEntityCreationBehavior.AlwaysCreateInstance)
                              .ToList();
             }
-            
+
             using (var db = CreateContext())
             {
                 // NullIfAllColumnsAreNull overrides AlwaysCreateInstance behavior
@@ -1330,6 +1331,24 @@ namespace Yamo.Playground.CS
                              .Select(x => x.ModifiedUserId ?? x.CreatedUserId)
                              .ToList();
 
+            }
+        }
+
+        public static void Test66()
+        {
+            using (var db = CreateContext())
+            {
+                var list = db.From<Blog>()
+                             .Select(x => new
+                             {
+                                 BitwiseAnd = x.Id & 1,
+                                 BitwiseOr = x.Id | 1,
+                                 BitwiseXor = x.Id ^ 1,
+                                 BitwiseNot = ~x.Id,
+                                 ShiftLeft = x.Id << 1,
+                                 ShiftRight = x.Id >> 1
+                             })
+                             .ToList();
             }
         }
 

--- a/Source/Test/Yamo.Test.SQLite/Tests/SelectWithWhereTests.vb
+++ b/Source/Test/Yamo.Test.SQLite/Tests/SelectWithWhereTests.vb
@@ -1,4 +1,6 @@
-﻿Imports Yamo.Test
+﻿Imports Microsoft.Data.Sqlite
+Imports Yamo.Test
+Imports Yamo.Test.Model
 Imports Yamo.Test.SQLite.Model
 
 Namespace Tests
@@ -228,6 +230,28 @@ Namespace Tests
         Assert.AreEqual(4, result.Count)
         CollectionAssert.AreEquivalent({items(0), items(1), items(2), items(4)}, result)
       End Using
+    End Sub
+
+    Protected Overrides Sub SelectRecordUsingXorOperator(expected As ICollection)
+      Try
+        Using db = CreateDbContext()
+          Dim result = db.From(Of ItemWithAllSupportedValues).
+                          Where(Function(x) (x.IntColumn Xor 3) < 2).
+                          SelectAll().ToList()
+
+          Assert.AreEqual(2, result.Count)
+          CollectionAssert.AreEquivalent(expected, result)
+        End Using
+
+        Assert.Fail()
+      Catch ex As SqliteException
+        ' error: 'unrecognized token: "^"'
+        If Not ex.Message.Contains("^") Then
+          Assert.Fail(ex.Message)
+        End If
+      Catch ex As Exception
+        Assert.Fail(ex.Message)
+      End Try
     End Sub
 
     Protected Overloads Function CreateItems() As List(Of ItemWithOnlySQLiteSupportedFields)

--- a/Source/Test/Yamo.Test/Tests/SelectWithWhereTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithWhereTests.vb
@@ -1358,6 +1358,91 @@ Namespace Tests
     End Sub
 
     <TestMethod()>
+    Public Overridable Sub SelectRecordUsingBitwiseOperators()
+      Dim items = CreateItems()
+
+      items(0).IntColumn = 1
+      items(1).IntColumn = 2
+      items(2).IntColumn = 3
+      items(3).IntColumn = 4
+      items(4).IntColumn = 5
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) (x.IntColumn And 3) = 1).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        CollectionAssert.AreEquivalent({items(0), items(4)}, result)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) (x.IntColumn Or 3) = 7).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        CollectionAssert.AreEquivalent({items(3), items(4)}, result)
+      End Using
+
+      SelectRecordUsingXorOperator({items(1), items(2)})
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) -4 < (Not x.IntColumn)).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        CollectionAssert.AreEquivalent({items(0), items(1)}, result)
+      End Using
+    End Sub
+
+    Protected Overridable Sub SelectRecordUsingXorOperator(expected As ICollection)
+      ' NOTE: SQLite doesn't support XOR
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) (x.IntColumn Xor 3) < 2).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        CollectionAssert.AreEquivalent(expected, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectRecordUsingShiftOperators()
+      Dim items = CreateItems()
+
+      items(0).IntColumn = 1
+      items(1).IntColumn = 2
+      items(2).IntColumn = 3
+      items(3).IntColumn = 4
+      items(4).IntColumn = 5
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) (x.IntColumn << 3) < 24).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        CollectionAssert.AreEquivalent({items(0), items(1)}, result)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) (x.IntColumn >> 1) = 2).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        CollectionAssert.AreEquivalent({items(3), items(4)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
     Public Overridable Sub SelectRecordByMultipleWhereConditions()
       Dim items = CreateItems()
 


### PR DESCRIPTION
Following bitwise and shift operators can now be used to build SQL expression:

- `&` (bitwise AND)
- `|` (bitwise OR)
- `^` (bitwise exclusive OR)
- `~` (bitwise NOT)
- `<<` (left shift)
- `>>` (right shift)

NOTE: SQLite currently doesn't support `~`.