### PR TITLE
Changed evaluation of  `Nullable<T>.Value` access

### DIFF
--- a/Source/Samples/Yamo.Playground.CS/Program.cs
+++ b/Source/Samples/Yamo.Playground.CS/Program.cs
@@ -88,7 +88,8 @@ namespace Yamo.Playground.CS
             //Test63();
             //Test64();
             //Test65();
-            Test66();
+            //Test66();
+            Test67();
         }
 
         public static MyContext CreateContext()
@@ -1348,6 +1349,29 @@ namespace Yamo.Playground.CS
                                  ShiftLeft = x.Id << 1,
                                  ShiftRight = x.Id >> 1
                              })
+                             .ToList();
+            }
+        }
+
+        public static void Test67()
+        {
+            using (var db = CreateContext())
+            {
+                int userId = 42;
+
+                var list = db.From<Blog>()
+                             .Where(x => x.ModifiedUserId.Value == userId)
+                             .SelectAll()
+                             .ToList();
+            }
+
+            using (var db = CreateContext())
+            {
+                int? userId = null;
+
+                var list = db.From<Blog>()
+                             .Where(x => x.ModifiedUserId.Value == userId.Value)
+                             .SelectAll()
                              .ToList();
             }
         }

--- a/Source/Source/Yamo/Internal/SqlExpressionVisitor.vb
+++ b/Source/Source/Yamo/Internal/SqlExpressionVisitor.vb
@@ -1005,11 +1005,7 @@ Namespace Internal
       If nodeIsEntityMemberAccess Then
         AppendEntityMemberAccess(entityIndex, memberName)
       Else
-        If IsInNullableValueAccess() Then
-          AppendNewParameter(Evaluate(m_Stack(1).Node))
-        Else
-          AppendNewParameter(Evaluate(node))
-        End If
+        AppendNewParameter(Evaluate(node))
       End If
 
       ExpandToBooleanComparisonIfNeeded(node)

--- a/Source/Test/Yamo.Test.VB/Tests/ExpressionTests.vb
+++ b/Source/Test/Yamo.Test.VB/Tests/ExpressionTests.vb
@@ -15,26 +15,62 @@ Namespace Tests
 
     Public FieldValue As Int32 = 401
 
-    Public Property PropertyValue As Int32 = 402
+    Public FieldNullableValue As Int32? = 402
+
+    Public FieldNullableValueNull As Int32? = Nothing
+
+    Public Property PropertyValue As Int32 = 403
+
+    Public Property PropertyNullableValue As Int32? = 404
+
+    Public Property PropertyNullableValueNull As Int32? = Nothing
 
     Public Property IndexerPropertyValue(index As Int32) As Int32
       Get
-        Return 403 + index
+        Return 405 + index
       End Get
       Set(ByVal value As Int32)
       End Set
     End Property
 
-    Public Function GetValue() As Int32
-      Return 404
-    End Function
+    Public Property IndexerPropertyNullableValue(index As Int32) As Int32?
+      Get
+        Return 406 + index
+      End Get
+      Set(ByVal value As Int32?)
+      End Set
+    End Property
 
-    Public Function GetValue(param1 As Int32, param2 As Int32) As Int32
-      Return 405 + param1 + param2
+    Public Property IndexerPropertyNullableValueNull(index As Int32) As Int32?
+      Get
+        Return Nothing
+      End Get
+      Set(ByVal value As Int32?)
+      End Set
+    End Property
+
+    Public Function GetValue() As Int32
+      Return 407
     End Function
 
     Public Function GetNullableValue() As Int32?
-      Return 406
+      Return 408
+    End Function
+
+    Public Function GetNullableValueNull() As Int32?
+      Return Nothing
+    End Function
+
+    Public Function GetValue(param1 As Int32, param2 As Int32) As Int32
+      Return 409 + param1 + param2
+    End Function
+
+    Public Function GetNullableValue(param1 As Int32, param2 As Int32) As Int32?
+      Return 410 + param1 + param2
+    End Function
+
+    Public Function GetNullableValueNull(param1 As Int32, param2 As Int32) As Int32?
+      Return Nothing
     End Function
 
   End Module
@@ -47,46 +83,122 @@ Namespace Tests
 
     Private m_FieldValue As Int32 = 201
 
-    Private Shared m_StaticFieldValue As Int32 = 202
+    Private m_FieldNullableValue As Int32? = 202
 
-    Private Property PropertyValue As Int32 = 203
+    Private m_FieldNullableValueNull As Int32? = Nothing
 
-    Private Shared Property StaticPropertyValue As Int32 = 204
+    Private Shared m_StaticFieldValue As Int32 = 203
+
+    Private Shared m_StaticFieldNullableValue As Int32? = 204
+
+    Private Shared m_StaticFieldNullableValueNull As Int32? = Nothing
+
+    Private Property PropertyValue As Int32 = 205
+
+    Private Property PropertyNullableValue As Int32? = 206
+
+    Private Property PropertyNullableValueNull As Int32? = Nothing
+
+    Private Shared Property StaticPropertyValue As Int32 = 207
+
+    Private Shared Property StaticPropertyNullableValue As Int32? = 208
+
+    Private Shared Property StaticPropertyNullableValueNull As Int32? = Nothing
 
     Public Property IndexerPropertyValue(index As Int32) As Int32
       Get
-        Return 205 + index
+        Return 209 + index
       End Get
       Set(ByVal value As Int32)
+      End Set
+    End Property
+
+    Public Property IndexerPropertyNullableValue(index As Int32) As Int32?
+      Get
+        Return 210 + index
+      End Get
+      Set(ByVal value As Int32?)
+      End Set
+    End Property
+
+    Public Property IndexerPropertyNullableValueNull(index As Int32) As Int32?
+      Get
+        Return Nothing
+      End Get
+      Set(ByVal value As Int32?)
       End Set
     End Property
 
     Public Shared Property StaticIndexerPropertyValue(index As Int32) As Int32
       Get
-        Return 206 + index
+        Return 211 + index
       End Get
       Set(ByVal value As Int32)
       End Set
     End Property
 
-    Private Function GetValue() As Int32
-      Return 207
-    End Function
+    Public Shared Property StaticIndexerPropertyNullableValue(index As Int32) As Int32?
+      Get
+        Return 212 + index
+      End Get
+      Set(ByVal value As Int32?)
+      End Set
+    End Property
 
-    Private Function GetValue(param1 As Int32, param2 As Int32) As Int32
-      Return 208 + param1 + param2
+    Public Shared Property StaticIndexerPropertyNullableValueNull(index As Int32) As Int32?
+      Get
+        Return Nothing
+      End Get
+      Set(ByVal value As Int32?)
+      End Set
+    End Property
+
+    Private Function GetValue() As Int32
+      Return 213
     End Function
 
     Private Function GetNullableValue() As Int32?
-      Return 209
+      Return 214
+    End Function
+
+    Private Function GetNullableValueNull() As Int32?
+      Return Nothing
+    End Function
+
+    Private Function GetValue(param1 As Int32, param2 As Int32) As Int32
+      Return 215 + param1 + param2
+    End Function
+
+    Private Function GetNullableValue(param1 As Int32, param2 As Int32) As Int32?
+      Return 216 + param1 + param2
+    End Function
+
+    Private Function GetNullableValueNull(param1 As Int32, param2 As Int32) As Int32?
+      Return Nothing
     End Function
 
     Private Shared Function GetStaticValue() As Int32
-      Return 210
+      Return 217
+    End Function
+
+    Private Shared Function GetStaticNullableValue() As Int32?
+      Return 218
+    End Function
+
+    Private Shared Function GetStaticNullableValueNull() As Int32?
+      Return Nothing
     End Function
 
     Private Shared Function GetStaticValue(param1 As Int32, param2 As Int32) As Int32
-      Return 211 + param1 + param2
+      Return 219 + param1 + param2
+    End Function
+
+    Private Shared Function GetStaticNullableValue(param1 As Int32, param2 As Int32) As Int32?
+      Return 220 + param1 + param2
+    End Function
+
+    Private Shared Function GetStaticNullableValueNull(param1 As Int32, param2 As Int32) As Int32?
+      Return Nothing
     End Function
 
     Private Class Class1
@@ -95,46 +207,122 @@ Namespace Tests
 
       Public FieldValue As Int32 = 301
 
-      Public Shared StaticFieldValue As Int32 = 302
+      Public FieldNullableValue As Int32? = 302
 
-      Public Property PropertyValue As Int32 = 303
+      Public FieldNullableValueNull As Int32? = Nothing
 
-      Public Shared Property StaticPropertyValue As Int32 = 304
+      Public Shared StaticFieldValue As Int32 = 303
+
+      Public Shared StaticFieldNullableValue As Int32? = 304
+
+      Public Shared StaticFieldNullableValueNull As Int32? = Nothing
+
+      Public Property PropertyValue As Int32 = 305
+
+      Public Property PropertyNullableValue As Int32? = 306
+
+      Public Property PropertyNullableValueNull As Int32? = Nothing
+
+      Public Shared Property StaticPropertyValue As Int32 = 307
+
+      Public Shared Property StaticPropertyNullableValue As Int32? = 308
+
+      Public Shared Property StaticPropertyNullableValueNull As Int32? = Nothing
 
       Public Property IndexerPropertyValue(index As Int32) As Int32
         Get
-          Return 305 + index
+          Return 309 + index
         End Get
         Set(ByVal value As Int32)
+        End Set
+      End Property
+
+      Public Property IndexerPropertyNullableValue(index As Int32) As Int32?
+        Get
+          Return 310 + index
+        End Get
+        Set(ByVal value As Int32?)
+        End Set
+      End Property
+
+      Public Property IndexerPropertyNullableValueNull(index As Int32) As Int32?
+        Get
+          Return Nothing
+        End Get
+        Set(ByVal value As Int32?)
         End Set
       End Property
 
       Public Shared Property StaticIndexerPropertyValue(index As Int32) As Int32
         Get
-          Return 306 + index
+          Return 311 + index
         End Get
         Set(ByVal value As Int32)
         End Set
       End Property
 
-      Public Function GetValue() As Int32
-        Return 307
-      End Function
+      Public Shared Property StaticIndexerPropertyNullableValue(index As Int32) As Int32?
+        Get
+          Return 312 + index
+        End Get
+        Set(ByVal value As Int32?)
+        End Set
+      End Property
 
-      Public Function GetValue(param1 As Int32, param2 As Int32) As Int32
-        Return 308 + param1 + param2
+      Public Shared Property StaticIndexerPropertyNullableValueNull(index As Int32) As Int32?
+        Get
+          Return Nothing
+        End Get
+        Set(ByVal value As Int32?)
+        End Set
+      End Property
+
+      Public Function GetValue() As Int32
+        Return 313
       End Function
 
       Public Function GetNullableValue() As Int32?
-        Return 309
+        Return 314
+      End Function
+
+      Public Function GetNullableValueNull() As Int32?
+        Return Nothing
+      End Function
+
+      Public Function GetValue(param1 As Int32, param2 As Int32) As Int32
+        Return 315 + param1 + param2
+      End Function
+
+      Public Function GetNullableValue(param1 As Int32, param2 As Int32) As Int32?
+        Return 316 + param1 + param2
+      End Function
+
+      Public Function GetNullableValueNull(param1 As Int32, param2 As Int32) As Int32?
+        Return Nothing
       End Function
 
       Public Shared Function GetStaticValue() As Int32
-        Return 310
+        Return 317
+      End Function
+
+      Public Shared Function GetStaticNullableValue() As Int32?
+        Return 318
+      End Function
+
+      Public Shared Function GetStaticNullableValueNull() As Int32?
+        Return Nothing
       End Function
 
       Public Shared Function GetStaticValue(param1 As Int32, param2 As Int32) As Int32
-        Return 311 + param1 + param2
+        Return 319 + param1 + param2
+      End Function
+
+      Public Shared Function GetStaticNullableValue(param1 As Int32, param2 As Int32) As Int32?
+        Return 320 + param1 + param2
+      End Function
+
+      Public Shared Function GetStaticNullableValueNull(param1 As Int32, param2 As Int32) As Int32?
+        Return Nothing
       End Function
 
     End Class
@@ -149,12 +337,16 @@ Namespace Tests
         Return False
       End Function
 
-      Public Function GetNullableTrueValue() As Boolean?
+      Public Function GetNullableValueTrue() As Boolean?
         Return True
       End Function
 
-      Public Function GetNullableFalseValue() As Boolean?
+      Public Function GetNullableValueFalse() As Boolean?
         Return False
+      End Function
+
+      Public Function GetNullableValueNull() As Boolean?
+        Return Nothing
       End Function
 
     End Class
@@ -167,17 +359,34 @@ Namespace Tests
         Dim visitor = CreateSqlExpressionVisitor(db)
         Dim result As SqlString
 
+        Dim localValue As Int32
+        Dim localNullableValue As Int32?
+
+        Dim localParam = 10000
+
         ' constant
         result = TranslateCondition(visitor, Function(x) x.IntColumn = 100)
         Assert.AreEqual("[T0].[IntColumn] = 100", result.Sql)
         Assert.AreEqual(0, result.Parameters.Count)
 
         ' local value (captured closure)
-        Dim localValue = 101
+        localValue = 101
         result = TranslateCondition(visitor, Function(x) x.IntColumn = localValue)
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
+
+        localNullableValue = 102
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = localNullableValue.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(localNullableValue, result.Parameters(0).Value)
+
+        localNullableValue = Nothing
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = localNullableValue.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(localNullableValue, result.Parameters(0).Value)
 
         ' --------------------------------------------------------------------------------------
 
@@ -192,11 +401,31 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(m_FieldValue, result.Parameters(0).Value)
 
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = m_FieldNullableValue.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(m_FieldNullableValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = m_FieldNullableValueNull.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(m_FieldNullableValueNull, result.Parameters(0).Value)
+
         ' static field
         result = TranslateCondition(visitor, Function(x) x.IntColumn = m_StaticFieldValue)
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(m_StaticFieldValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = m_StaticFieldNullableValue.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(m_StaticFieldNullableValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = m_StaticFieldNullableValueNull.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(m_StaticFieldNullableValueNull, result.Parameters(0).Value)
 
         ' property
         result = TranslateCondition(visitor, Function(x) x.IntColumn = Me.PropertyValue)
@@ -204,11 +433,31 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(Me.PropertyValue, result.Parameters(0).Value)
 
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Me.PropertyNullableValue.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Me.PropertyNullableValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Me.PropertyNullableValueNull.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Me.PropertyNullableValueNull, result.Parameters(0).Value)
+
         ' static property
         result = TranslateCondition(visitor, Function(x) x.IntColumn = StaticPropertyValue)
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(StaticPropertyValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = StaticPropertyNullableValue.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(StaticPropertyNullableValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = StaticPropertyNullableValueNull.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(StaticPropertyNullableValueNull, result.Parameters(0).Value)
 
         ' indexer property
         result = TranslateCondition(visitor, Function(x) x.IntColumn = Me.IndexerPropertyValue(10000))
@@ -216,11 +465,31 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(Me.IndexerPropertyValue(10000), result.Parameters(0).Value)
 
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Me.IndexerPropertyNullableValue(10000).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Me.IndexerPropertyNullableValue(10000), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Me.IndexerPropertyNullableValueNull(10000).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Me.IndexerPropertyNullableValueNull(10000), result.Parameters(0).Value)
+
         ' static indexer property
         result = TranslateCondition(visitor, Function(x) x.IntColumn = StaticIndexerPropertyValue(10000))
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(StaticIndexerPropertyValue(10000), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = StaticIndexerPropertyNullableValue(10000).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(StaticIndexerPropertyNullableValue(10000), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = StaticIndexerPropertyNullableValueNull(10000).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(StaticIndexerPropertyNullableValueNull(10000), result.Parameters(0).Value)
 
         ' function
         result = TranslateCondition(visitor, Function(x) x.IntColumn = GetValue())
@@ -228,18 +497,31 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(GetValue(), result.Parameters(0).Value)
 
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = GetNullableValue().Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(GetNullableValue(), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = GetNullableValueNull().Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(GetNullableValueNull(), result.Parameters(0).Value)
+
         ' function with parameters
-        Dim localParam = 10000
         result = TranslateCondition(visitor, Function(x) x.IntColumn = GetValue(10000, localParam))
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(GetValue(10000, localParam), result.Parameters(0).Value)
 
-        ' function with nullable return value
-        result = TranslateCondition(visitor, Function(x) x.IntColumn = GetNullableValue().Value)
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = GetNullableValue(10000, localParam).Value)
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(GetNullableValue(), result.Parameters(0).Value)
+        Assert.AreEqual(GetNullableValue(10000, localParam), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = GetNullableValueNull(10000, localParam).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(GetNullableValueNull(10000, localParam), result.Parameters(0).Value)
 
         ' static function
         result = TranslateCondition(visitor, Function(x) x.IntColumn = GetStaticValue())
@@ -247,11 +529,31 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(GetStaticValue(), result.Parameters(0).Value)
 
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = GetStaticNullableValue().Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(GetStaticNullableValue(), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = GetStaticNullableValueNull().Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(GetStaticNullableValueNull(), result.Parameters(0).Value)
+
         ' static function with parameters
         result = TranslateCondition(visitor, Function(x) x.IntColumn = GetStaticValue(10000, localParam))
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(GetStaticValue(10000, localParam), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = GetStaticNullableValue(10000, localParam).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(GetStaticNullableValue(10000, localParam), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = GetStaticNullableValueNull(10000, localParam).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(GetStaticNullableValueNull(10000, localParam), result.Parameters(0).Value)
 
         ' --------------------------------------------------------------------------------------
 
@@ -268,11 +570,31 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(c.FieldValue, result.Parameters(0).Value)
 
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = c.FieldNullableValue.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(c.FieldNullableValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = c.FieldNullableValueNull.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(c.FieldNullableValueNull, result.Parameters(0).Value)
+
         ' static field
         result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.StaticFieldValue)
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(Class1.StaticFieldValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.StaticFieldNullableValue.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Class1.StaticFieldNullableValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.StaticFieldNullableValueNull.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Class1.StaticFieldNullableValueNull, result.Parameters(0).Value)
 
         ' property
         result = TranslateCondition(visitor, Function(x) x.IntColumn = c.PropertyValue)
@@ -280,11 +602,31 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(c.PropertyValue, result.Parameters(0).Value)
 
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = c.PropertyNullableValue.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(c.PropertyNullableValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = c.PropertyNullableValueNull.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(c.PropertyNullableValueNull, result.Parameters(0).Value)
+
         ' static property
         result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.StaticPropertyValue)
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(Class1.StaticPropertyValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.StaticPropertyNullableValue.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Class1.StaticPropertyNullableValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.StaticPropertyNullableValueNull.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Class1.StaticPropertyNullableValueNull, result.Parameters(0).Value)
 
         ' indexer property
         result = TranslateCondition(visitor, Function(x) x.IntColumn = c.IndexerPropertyValue(10000))
@@ -292,11 +634,31 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(c.IndexerPropertyValue(10000), result.Parameters(0).Value)
 
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = c.IndexerPropertyNullableValue(10000).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(c.IndexerPropertyNullableValue(10000), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = c.IndexerPropertyNullableValueNull(10000).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(c.IndexerPropertyNullableValueNull(10000), result.Parameters(0).Value)
+
         ' static indexer property
         result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.StaticIndexerPropertyValue(10000))
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(Class1.StaticIndexerPropertyValue(10000), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.StaticIndexerPropertyNullableValue(10000).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Class1.StaticIndexerPropertyNullableValue(10000), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.StaticIndexerPropertyNullableValueNull(10000).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Class1.StaticIndexerPropertyNullableValueNull(10000), result.Parameters(0).Value)
 
         ' function
         result = TranslateCondition(visitor, Function(x) x.IntColumn = c.GetValue())
@@ -304,17 +666,31 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(c.GetValue(), result.Parameters(0).Value)
 
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = c.GetNullableValue().Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(c.GetNullableValue(), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = c.GetNullableValueNull().Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(c.GetNullableValueNull(), result.Parameters(0).Value)
+
         ' function with parameters
         result = TranslateCondition(visitor, Function(x) x.IntColumn = c.GetValue(10000, localParam))
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(c.GetValue(10000, localParam), result.Parameters(0).Value)
 
-        ' function with nullable return value
-        result = TranslateCondition(visitor, Function(x) x.IntColumn = c.GetNullableValue().Value)
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = c.GetNullableValue(10000, localParam).Value)
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValue(10000, localParam), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = c.GetNullableValueNull(10000, localParam).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(c.GetNullableValueNull(10000, localParam), result.Parameters(0).Value)
 
         ' static function
         result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.GetStaticValue())
@@ -322,11 +698,31 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(Class1.GetStaticValue(), result.Parameters(0).Value)
 
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.GetStaticNullableValue().Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Class1.GetStaticNullableValue(), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.GetStaticNullableValueNull().Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Class1.GetStaticNullableValueNull(), result.Parameters(0).Value)
+
         ' static function with parameters
         result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.GetStaticValue(10000, localParam))
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(Class1.GetStaticValue(10000, localParam), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.GetStaticNullableValue(10000, localParam).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Class1.GetStaticNullableValue(10000, localParam), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Class1.GetStaticNullableValueNull(10000, localParam).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Class1.GetStaticNullableValueNull(10000, localParam), result.Parameters(0).Value)
 
         ' --------------------------------------------------------------------------------------
 
@@ -341,11 +737,31 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(Module1.FieldValue, result.Parameters(0).Value)
 
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.FieldNullableValue.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Module1.FieldNullableValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.FieldNullableValueNull.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Module1.FieldNullableValueNull, result.Parameters(0).Value)
+
         ' property
         result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.PropertyValue)
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(Module1.PropertyValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.PropertyNullableValue.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Module1.PropertyNullableValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.PropertyNullableValueNull.Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Module1.PropertyNullableValueNull, result.Parameters(0).Value)
 
         ' indexer property
         result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.IndexerPropertyValue(10000))
@@ -353,11 +769,31 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(Module1.IndexerPropertyValue(10000), result.Parameters(0).Value)
 
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.IndexerPropertyNullableValue(10000).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Module1.IndexerPropertyNullableValue(10000), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.IndexerPropertyNullableValueNull(10000).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Module1.IndexerPropertyNullableValueNull(10000), result.Parameters(0).Value)
+
         ' function
         result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.GetValue())
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(Module1.GetValue(), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.GetNullableValue().Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Module1.GetNullableValue(), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.GetNullableValueNull().Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Module1.GetNullableValueNull(), result.Parameters(0).Value)
 
         ' function with parameters
         result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.GetValue(10000, localParam))
@@ -365,11 +801,15 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(Module1.GetValue(10000, localParam), result.Parameters(0).Value)
 
-        ' function with nullable return value
-        result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.GetNullableValue().Value)
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.GetNullableValue(10000, localParam).Value)
         Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(Module1.GetNullableValue(), result.Parameters(0).Value)
+        Assert.AreEqual(Module1.GetNullableValue(10000, localParam), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.IntColumn = Module1.GetNullableValueNull(10000, localParam).Value)
+        Assert.AreEqual("[T0].[IntColumn] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(Module1.GetNullableValueNull(10000, localParam), result.Parameters(0).Value)
 
         ' --------------------------------------------------------------------------------------
 
@@ -683,10 +1123,15 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value = c.GetNullableTrueValue().Value)
+        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value = c.GetNullableValueTrue().Value)
         Assert.AreEqual("[T0].[BitColumnNull] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableTrueValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value = c.GetNullableValueTrue().Value)
+        Assert.AreEqual("[T0].[BitColumnNull] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value = Sql.Exp.Raw(Of Boolean?)("1").Value)
         Assert.AreEqual("[T0].[BitColumnNull] = 1", result.Sql)
@@ -708,10 +1153,10 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value = c.GetNullableFalseValue().Value)
+        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value = c.GetNullableValueFalse().Value)
         Assert.AreEqual("[T0].[BitColumnNull] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableFalseValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueFalse(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value = Sql.Exp.Raw(Of Boolean?)("0").Value)
         Assert.AreEqual("[T0].[BitColumnNull] = 0", result.Sql)
@@ -733,10 +1178,10 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) Not x.BitColumnNull.Value = c.GetNullableTrueValue().Value)
+        result = TranslateCondition(visitor, Function(x) Not x.BitColumnNull.Value = c.GetNullableValueTrue().Value)
         Assert.AreEqual("NOT [T0].[BitColumnNull] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableTrueValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) Not x.BitColumnNull.Value = Sql.Exp.Raw(Of Boolean?)("1").Value)
         Assert.AreEqual("NOT [T0].[BitColumnNull] = 1", result.Sql)
@@ -758,10 +1203,10 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) Not x.BitColumnNull.Value = c.GetNullableFalseValue().Value)
+        result = TranslateCondition(visitor, Function(x) Not x.BitColumnNull.Value = c.GetNullableValueFalse().Value)
         Assert.AreEqual("NOT [T0].[BitColumnNull] = @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableFalseValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueFalse(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) Not x.BitColumnNull.Value = Sql.Exp.Raw(Of Boolean?)("0").Value)
         Assert.AreEqual("NOT [T0].[BitColumnNull] = 0", result.Sql)
@@ -783,10 +1228,10 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value <> c.GetNullableTrueValue().Value)
+        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value <> c.GetNullableValueTrue().Value)
         Assert.AreEqual("[T0].[BitColumnNull] <> @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableTrueValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value <> Sql.Exp.Raw(Of Boolean?)("1").Value)
         Assert.AreEqual("[T0].[BitColumnNull] <> 1", result.Sql)
@@ -808,10 +1253,10 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value <> c.GetNullableFalseValue().Value)
+        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value <> c.GetNullableValueFalse().Value)
         Assert.AreEqual("[T0].[BitColumnNull] <> @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableFalseValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueFalse(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value <> Sql.Exp.Raw(Of Boolean?)("0").Value)
         Assert.AreEqual("[T0].[BitColumnNull] <> 0", result.Sql)
@@ -833,10 +1278,10 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) Not x.BitColumnNull.Value <> c.GetNullableTrueValue().Value)
+        result = TranslateCondition(visitor, Function(x) Not x.BitColumnNull.Value <> c.GetNullableValueTrue().Value)
         Assert.AreEqual("NOT [T0].[BitColumnNull] <> @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableTrueValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) Not x.BitColumnNull.Value <> Sql.Exp.Raw(Of Boolean?)("1").Value)
         Assert.AreEqual("NOT [T0].[BitColumnNull] <> 1", result.Sql)
@@ -858,10 +1303,10 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) Not x.BitColumnNull.Value <> c.GetNullableFalseValue().Value)
+        result = TranslateCondition(visitor, Function(x) Not x.BitColumnNull.Value <> c.GetNullableValueFalse().Value)
         Assert.AreEqual("NOT [T0].[BitColumnNull] <> @p0", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableFalseValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueFalse(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) Not x.BitColumnNull.Value <> Sql.Exp.Raw(Of Boolean?)("0").Value)
         Assert.AreEqual("NOT [T0].[BitColumnNull] <> 0", result.Sql)
@@ -883,10 +1328,10 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) c.GetNullableTrueValue().Value)
+        result = TranslateCondition(visitor, Function(x) c.GetNullableValueTrue().Value)
         Assert.AreEqual("@p0 = 1", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableTrueValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) Sql.Exp.Raw(Of Boolean?)("BitColumnNull = 1").Value)
         Assert.AreEqual("BitColumnNull = 1", result.Sql)
@@ -908,14 +1353,38 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) Not c.GetNullableTrueValue().Value)
+        result = TranslateCondition(visitor, Function(x) Not c.GetNullableValueTrue().Value)
         Assert.AreEqual("NOT @p0 = 1", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableTrueValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) Not Sql.Exp.Raw(Of Boolean?)("BitColumnNull = 1").Value)
         Assert.AreEqual("NOT BitColumnNull = 1", result.Sql)
         Assert.AreEqual(0, result.Parameters.Count)
+
+        ' --------------------------------------------------------------------------------------
+
+        localValue = Nothing
+        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value = localValue.Value)
+        Assert.AreEqual("[T0].[BitColumnNull] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(localValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value = c.GetNullableValueNull().Value)
+        Assert.AreEqual("[T0].[BitColumnNull] = @p0", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(c.GetNullableValueNull(), result.Parameters(0).Value)
+
+        localValue = Nothing
+        result = TranslateCondition(visitor, Function(x) localValue.Value)
+        Assert.AreEqual("@p0 = 1", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(localValue, result.Parameters(0).Value)
+
+        result = TranslateCondition(visitor, Function(x) c.GetNullableValueNull().Value)
+        Assert.AreEqual("@p0 = 1", result.Sql)
+        Assert.AreEqual(1, result.Parameters.Count)
+        Assert.AreEqual(c.GetNullableValueNull(), result.Parameters(0).Value)
 
         ' --------------------------------------------------------------------------------------
 
@@ -930,11 +1399,11 @@ Namespace Tests
         ' --------------------------------------------------------------------------------------
 
         localValue = True
-        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value = localValue.Value AndAlso c.GetNullableTrueValue().Value OrElse Not Sql.Exp.Raw(Of Boolean?)("BitColumnNull = 1").Value)
+        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.Value = localValue.Value AndAlso c.GetNullableValueTrue().Value OrElse Not Sql.Exp.Raw(Of Boolean?)("BitColumnNull = 1").Value)
         Assert.AreEqual("(([T0].[BitColumnNull] = @p0 AND @p1 = 1) OR NOT BitColumnNull = 1)", result.Sql)
         Assert.AreEqual(2, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
-        Assert.AreEqual(c.GetNullableTrueValue(), result.Parameters(1).Value)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(1).Value)
 
       End Using
     End Sub
@@ -992,10 +1461,10 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) c.GetNullableTrueValue().HasValue)
+        result = TranslateCondition(visitor, Function(x) c.GetNullableValueTrue().HasValue)
         Assert.AreEqual("@p0 IS NOT NULL", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableTrueValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) Sql.Exp.Raw(Of Boolean?)("BitColumnNull").HasValue)
         Assert.AreEqual("BitColumnNull IS NOT NULL", result.Sql)
@@ -1017,10 +1486,10 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) Not c.GetNullableTrueValue().HasValue)
+        result = TranslateCondition(visitor, Function(x) Not c.GetNullableValueTrue().HasValue)
         Assert.AreEqual("@p0 IS NULL", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableTrueValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) Not Sql.Exp.Raw(Of Boolean?)("BitColumnNull").HasValue)
         Assert.AreEqual("BitColumnNull IS NULL", result.Sql)
@@ -1029,11 +1498,11 @@ Namespace Tests
         ' --------------------------------------------------------------------------------------
 
         localValue = True
-        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.HasValue AndAlso Not x.BitColumnNull.HasValue And localValue.HasValue OrElse Not c.GetNullableTrueValue().HasValue Or Sql.Exp.Raw(Of Boolean?)("BitColumnNull").HasValue)
+        result = TranslateCondition(visitor, Function(x) x.BitColumnNull.HasValue AndAlso Not x.BitColumnNull.HasValue And localValue.HasValue OrElse Not c.GetNullableValueTrue().HasValue Or Sql.Exp.Raw(Of Boolean?)("BitColumnNull").HasValue)
         Assert.AreEqual("(((([T0].[BitColumnNull] IS NOT NULL AND [T0].[BitColumnNull] IS NULL) AND @p0 IS NOT NULL) OR @p1 IS NULL) OR BitColumnNull IS NOT NULL)", result.Sql)
         Assert.AreEqual(2, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
-        Assert.AreEqual(c.GetNullableTrueValue(), result.Parameters(1).Value)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(1).Value)
 
         ' TODO: SIP - fix: "nullable.HasValue = True"
 
@@ -1063,10 +1532,10 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) c.GetNullableTrueValue() Is Nothing)
+        result = TranslateCondition(visitor, Function(x) c.GetNullableValueTrue() Is Nothing)
         Assert.AreEqual("@p0 IS NULL", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableTrueValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) Sql.Exp.Raw(Of Boolean?)("BitColumnNull") Is Nothing)
         Assert.AreEqual("BitColumnNull IS NULL", result.Sql)
@@ -1088,10 +1557,10 @@ Namespace Tests
         Assert.AreEqual(1, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
 
-        result = TranslateCondition(visitor, Function(x) c.GetNullableTrueValue() IsNot Nothing)
+        result = TranslateCondition(visitor, Function(x) c.GetNullableValueTrue() IsNot Nothing)
         Assert.AreEqual("@p0 IS NOT NULL", result.Sql)
         Assert.AreEqual(1, result.Parameters.Count)
-        Assert.AreEqual(c.GetNullableTrueValue(), result.Parameters(0).Value)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(0).Value)
 
         result = TranslateCondition(visitor, Function(x) Sql.Exp.Raw(Of Boolean?)("BitColumnNull") IsNot Nothing)
         Assert.AreEqual("BitColumnNull IS NOT NULL", result.Sql)
@@ -1100,11 +1569,11 @@ Namespace Tests
         ' --------------------------------------------------------------------------------------
 
         localValue = True
-        result = TranslateCondition(visitor, Function(x) x.BitColumnNull Is Nothing AndAlso x.BitColumnNull IsNot Nothing And localValue Is Nothing OrElse c.GetNullableTrueValue() IsNot Nothing Or Sql.Exp.Raw(Of Boolean?)("BitColumnNull") Is Nothing)
+        result = TranslateCondition(visitor, Function(x) x.BitColumnNull Is Nothing AndAlso x.BitColumnNull IsNot Nothing And localValue Is Nothing OrElse c.GetNullableValueTrue() IsNot Nothing Or Sql.Exp.Raw(Of Boolean?)("BitColumnNull") Is Nothing)
         Assert.AreEqual("(((([T0].[BitColumnNull] IS NULL AND [T0].[BitColumnNull] IS NOT NULL) AND @p0 IS NULL) OR @p1 IS NOT NULL) OR BitColumnNull IS NULL)", result.Sql)
         Assert.AreEqual(2, result.Parameters.Count)
         Assert.AreEqual(localValue, result.Parameters(0).Value)
-        Assert.AreEqual(c.GetNullableTrueValue(), result.Parameters(1).Value)
+        Assert.AreEqual(c.GetNullableValueTrue(), result.Parameters(1).Value)
 
       End Using
     End Sub


### PR DESCRIPTION
When building SQL expressions, accessing `Nullable<T>.Value` on an entity member is ignored. Same happens on some other places, e.g. on results of SQL helper methods. This behavior is for convenience.

Example:

```cs
using (var db = CreateContext())
{
    int userId = 42;

    var list = db.From<Blog>()
                 .Where(x => x.ModifiedUserId.Value == userId)
                 .SelectAll()
                 .ToList();
}
```

However, when expression is evaluated, `.Value` is called to access the underlying value:

```cs
using (var db = CreateContext())
{
    int? userId;

    // this works fine
    userId = 42;
    var list1 = db.From<Blog>()
                  .Where(x => x.ModifiedUserId.Value == userId.Value)
                  .SelectAll()
                  .ToList();

    // this will fail
    userId = null;
    var list2 = db.From<Blog>()
                  .Where(x => x.ModifiedUserId.Value == userId.Value)
                  .SelectAll()
                  .ToList();
}
```
Second query will fail because accessing `userId.Value` will result to an exception, since `userId` doesn't contain any underlying value.

So far, such cases should have been avoided (e.g. with `If` method).

This PR unifies handling of `Nullable<T>.Value`. From now on, it is always "ignored", even when the expression is evaluated. The result of the evaluation will be "the whole" nullable value, not it's underlying value.

Both queries in the example above will translate to the statement `...WHERE [T0].[ModifiedUserId] = @p0`. In the first select, `@p` will contain value `42`. In the second query, `@p` will contain value `null`.
